### PR TITLE
Add support for virtio-gpu

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,4 @@
+BasedOnStyle: LLVM
+IndentWidth: 4
+TabWidth: 4
+UseTab: Never

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
-KDIR ?= ~/linux
+KDIR ?= /usr/local/bin/linux
 DEV ?= /dev/sda1
 ARCH ?= arm64
-LOG ?= LOG_WARN
+LOG ?= LOG_INFO
 DEBUG ?= n
 
 export KDIR
@@ -9,15 +9,10 @@ export ARCH
 export LOG
 .PHONY: all env tools driver clean
 
-# check if KDIR is set
-ifeq ($(KDIR),)
-$(error Linux kernel directory is not set. Please set environment variable 'KDIR')
-endif
-
 all: tools driver
 
 env:
-	git submodule update --init --recursive
+	# git submodule update --init --recursive
 
 tools: env
 	$(MAKE) -C tools all

--- a/driver/Makefile
+++ b/driver/Makefile
@@ -6,9 +6,9 @@ else ifeq ($(ARCH), riscv)
 	COMPILE := riscv64-unknown-linux-gnu-
 endif
 
-EXTRA_CFLAGS += -I$(shell pwd)/../include -Werror -Wall
+EXTRA_CFLAGS += -I$(PWD)/include -Werror -Walla
 
-ivc-y := ivc_driver.o 
+ivc-y := ivc_driver.o
 
 .SECONDARY: \
         $(obj)/hivc_template.dtb.S \

--- a/examples/qemu-aarch64/virtio_cfg.json
+++ b/examples/qemu-aarch64/virtio_cfg.json
@@ -33,6 +33,15 @@
                         "tap": "tap0",
                         "mac": ["0x00", "0x16", "0x3e", "0x10", "0x10", "0x10"],
                         "status": "disable"
+                    },
+                    {
+                        "type": "gpu",
+                        "addr": "0xa003400",
+                        "len": "0x200",
+                        "irq": 74,
+                        "width": 1280,
+                        "height": 800,
+                        "status": "enable"
                     }
                 ]
         }

--- a/examples/qemu-aarch64/zone1_linux.json
+++ b/examples/qemu-aarch64/zone1_linux.json
@@ -12,6 +12,12 @@
         },
         {
             "type": "virtio",
+            "physical_start": "0xa003400",
+            "virtual_start": "0xa003400",
+            "size": "0x200"
+        },
+        {
+            "type": "virtio",
             "physical_start": "0xa003600",
             "virtual_start":  "0xa003600",
             "size": "0x200"
@@ -29,7 +35,7 @@
             "size": "0x200"
         }
     ],
-    "interrupts": [75, 76, 78],
+    "interrupts": [74, 75, 76, 78],
     "ivc_configs": [],
     "kernel_filepath": "./Image",
     "dtb_filepath": "./linux2.dtb",

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -4,7 +4,7 @@ ivc_demo_objects := ivc_demo.o
 hvisor_objects := $(filter-out $(ivc_demo_objects), $(objects))
 
 CFLAGS := -Wall -Wextra -DLOG_USE_COLOR -DHLOG=$(LOG)
-include_dirs := -I../include -I./include -I../cJSON/ -lpthread
+include_dirs := -I../include -I./include -I../cJSON/ -I/usr/aarch64-linux-gnu/include -I/usr/aarch64-linux-gnu/include/libdrm -L/usr/aarch64-linux-gnu/lib -ldrm -lpthread
 
 include $(sources:.c=.d)
 

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -4,7 +4,7 @@ ivc_demo_objects := ivc_demo.o
 hvisor_objects := $(filter-out $(ivc_demo_objects), $(objects))
 
 CFLAGS := -Wall -Wextra -DLOG_USE_COLOR -DHLOG=$(LOG)
-include_dirs := -I../include -I./include -I../cJSON/ -I/usr/aarch64-linux-gnu/include -I/usr/aarch64-linux-gnu/include/libdrm -L/usr/aarch64-linux-gnu/lib -ldrm -lpthread
+include_dirs := -I../include -I./include -I../cJSON/ -I/usr/aarch64-linux-gnu/include -I/usr/aarch64-linux-gnu/include/libdrm -L/usr/aarch64-linux-gnu/lib -ldrm -pthread
 
 include $(sources:.c=.d)
 

--- a/tools/hvisor.c
+++ b/tools/hvisor.c
@@ -9,17 +9,6 @@
 #include <getopt.h>
 #include <pthread.h>
 #include <signal.h>
-#include "hvisor.h"
-#include "cJSON.h"
-#include "event_monitor.h"
-#include "log.h"
-#include "virtio.h"
-#include "zone_config.h"
-#include <errno.h>
-#include <fcntl.h>
-#include <getopt.h>
-#include <pthread.h>
-#include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -28,69 +17,52 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
-#include <sys/stat.h>
-#include <sys/types.h>
-#include <unistd.h>
 
-static void __attribute__((noreturn)) help(int exit_status) {
 static void __attribute__((noreturn)) help(int exit_status) {
     printf("Invalid Parameters!\n");
     exit(exit_status);
 }
 
 void *read_file(char *filename, u_int64_t *filesize) {
-void *read_file(char *filename, u_int64_t *filesize) {
     int fd;
     struct stat st;
     void *buf;
     ssize_t len;
 
-
     fd = open(filename, O_RDONLY);
-    if (fd < 0) {
     if (fd < 0) {
         perror("read_file: open file failed");
         exit(1);
     }
 
     if (fstat(fd, &st) < 0) {
-    if (fstat(fd, &st) < 0) {
         perror("read_file: fstat failed");
         exit(1);
     }
 
-
     long page_size = sysconf(_SC_PAGESIZE);
-
-    // Calculate buffer size, ensuring alignment to page boundary
 
     // Calculate buffer size, ensuring alignment to page boundary
     ssize_t buf_size = (st.st_size + page_size - 1) & ~(page_size - 1);
 
-
     buf = malloc(buf_size);
     memset(buf, 0, buf_size);
 
-
     len = read(fd, buf, st.st_size);
-    if (len < 0) {
     if (len < 0) {
         perror("read_file: read failed");
         exit(1);
     }
 
-
     if (filesize)
         *filesize = len;
 
-
     close(fd);
-
 
     return buf;
 }
 
-int open_dev_hvisor() {
+int open_dev() {
     int fd = open("/dev/hvisor", O_RDWR);
     if (fd < 0) {
         perror("open hvisor failed");
@@ -117,24 +89,17 @@ static __u64 load_image_to_memory(const char *path, __u64 load_paddr) {
     int fd;       // File descriptor
     void *image_content,
         *virt_addr; // Pointers to image content and virtual address
-static __u64 load_image_to_memory(const char *path, __u64 load_paddr) {
-    __u64 size, page_size,
-        map_size; // Define variables: image size, page size, and map size
-    int fd;       // File descriptor
-    void *image_content,
-        *virt_addr; // Pointers to image content and virtual address
 
-    fd = open_dev_hvisor(); // Open hvisor device
+    fd = open_dev();
     // Load image content into memory
     image_content = read_file(path, &size);
 
-    page_size = sysconf(_SC_PAGESIZE); // Get system page size
-    map_size = (size + page_size - 1) &
-               ~(page_size -
-                 1); // Calculate map size, ensuring alignment to page boundary
+    page_size = sysconf(_SC_PAGESIZE);
+    map_size = (size + page_size - 1) & ~(page_size - 1);
 
     // Map the physical memory to virtual memory
-    virt_addr = mmap(NULL, map_size, PROT_READ | PROT_WRITE , MAP_SHARED, fd, load_paddr);
+    virt_addr = mmap(NULL, map_size, PROT_READ | PROT_WRITE, MAP_SHARED, fd,
+                     load_paddr);
 
     if (virt_addr == MAP_FAILED) {
         perror("Error mapping memory");
@@ -150,17 +115,17 @@ static __u64 load_image_to_memory(const char *path, __u64 load_paddr) {
     return map_size;
 }
 
-#define CHECK_JSON_NULL(json_ptr, json_name) \
-    if (json_ptr == NULL) { \
-        fprintf(stderr, "\'%s\' is missing in json file.\n", json_name); \
-        return -1; \
+#define CHECK_JSON_NULL(json_ptr, json_name)                                   \
+    if (json_ptr == NULL) {                                                    \
+        fprintf(stderr, "\'%s\' is missing in json file.\n", json_name);       \
+        return -1;                                                             \
     }
 
-#define CHECK_JSON_NULL_ERR_OUT(json_ptr, json_name) \
-    if (json_ptr == NULL) { \
-        fprintf(stderr, "\'%s\' is missing in json file.\n", json_name); \
-        goto err_out; \
-}
+#define CHECK_JSON_NULL_ERR_OUT(json_ptr, json_name)                           \
+    if (json_ptr == NULL) {                                                    \
+        fprintf(stderr, "\'%s\' is missing in json file.\n", json_name);       \
+        goto err_out;                                                          \
+    }
 
 static int parse_arch_config(cJSON *root, zone_config_t *config) {
     cJSON *arch_config_json = cJSON_GetObjectItem(root, "arch_config");
@@ -177,11 +142,11 @@ static int parse_arch_config(cJSON *root, zone_config_t *config) {
     cJSON *gicr_size_json = cJSON_GetObjectItem(arch_config_json, "gicr_size");
     cJSON *gits_size_json = cJSON_GetObjectItem(arch_config_json, "gits_size");
 
-    if (gicd_base_json == NULL || gicr_base_json == NULL ||
-        gicd_size_json == NULL || gicr_size_json == NULL) {
-        fprintf(stderr, "Missing fields in arch_config.\n");
-        return -1;
-    }
+    CHECK_JSON_NULL(gicd_base_json, "gicd_base")
+    CHECK_JSON_NULL(gicr_base_json, "gicr_base")
+    CHECK_JSON_NULL(gicd_size_json, "gicd_size")
+    CHECK_JSON_NULL(gicr_size_json, "gicr_size")
+
     if (gits_base_json == NULL || gits_size_json == NULL) {
         printf("No gits fields in arch_config.\n");
     } else {
@@ -214,10 +179,6 @@ static int parse_arch_config(cJSON *root, zone_config_t *config) {
         strtoull(plic_base_json->valuestring, NULL, 16);
     config->arch_config.plic_size =
         strtoull(plic_size_json->valuestring, NULL, 16);
-    config->arch_config.plic_base =
-        strtoull(plic_base_json->valuestring, NULL, 16);
-    config->arch_config.plic_size =
-        strtoull(plic_size_json->valuestring, NULL, 16);
 #endif
 
     return 0;
@@ -231,21 +192,14 @@ static int parse_pci_config(cJSON *root, zone_config_t *config) {
     }
 
 #ifdef ARM64
-#ifdef ARM64
     cJSON *ecam_base_json = cJSON_GetObjectItem(pci_config_json, "ecam_base");
     cJSON *io_base_json = cJSON_GetObjectItem(pci_config_json, "io_base");
-    cJSON *pci_io_base_json =
-        cJSON_GetObjectItem(pci_config_json, "pci_io_base");
     cJSON *pci_io_base_json =
         cJSON_GetObjectItem(pci_config_json, "pci_io_base");
     cJSON *mem32_base_json = cJSON_GetObjectItem(pci_config_json, "mem32_base");
     cJSON *pci_mem32_base_json =
         cJSON_GetObjectItem(pci_config_json, "pci_mem32_base");
-    cJSON *pci_mem32_base_json =
-        cJSON_GetObjectItem(pci_config_json, "pci_mem32_base");
     cJSON *mem64_base_json = cJSON_GetObjectItem(pci_config_json, "mem64_base");
-    cJSON *pci_mem64_base_json =
-        cJSON_GetObjectItem(pci_config_json, "pci_mem64_base");
     cJSON *pci_mem64_base_json =
         cJSON_GetObjectItem(pci_config_json, "pci_mem64_base");
     cJSON *ecam_size_json = cJSON_GetObjectItem(pci_config_json, "ecam_size");
@@ -253,15 +207,18 @@ static int parse_pci_config(cJSON *root, zone_config_t *config) {
     cJSON *mem32_size_json = cJSON_GetObjectItem(pci_config_json, "mem32_size");
     cJSON *mem64_size_json = cJSON_GetObjectItem(pci_config_json, "mem64_size");
 
-    if (ecam_base_json == NULL || io_base_json == NULL ||
-        mem32_base_json == NULL || mem64_base_json == NULL ||
-        ecam_size_json == NULL || io_size_json == NULL ||
-        mem32_size_json == NULL || mem64_size_json == NULL ||
-        pci_io_base_json == NULL || pci_mem32_base_json == NULL ||
-        pci_mem64_base_json == NULL) {
-        fprintf(stderr, "Missing fields in pci_config.\n");
-        return -1;
-    }
+    CHECK_JSON_NULL(ecam_base_json, "ecam_base")
+    CHECK_JSON_NULL(io_base_json, "io_base")
+    CHECK_JSON_NULL(mem32_base_json, "mem32_base")
+    CHECK_JSON_NULL(mem64_base_json, "mem64_base")
+    CHECK_JSON_NULL(ecam_size_json, "ecam_size")
+    CHECK_JSON_NULL(io_size_json, "io_size")
+    CHECK_JSON_NULL(mem32_size_json, "mem32_size")
+    CHECK_JSON_NULL(mem64_size_json, "mem64_size")
+    CHECK_JSON_NULL(pci_io_base_json, "pci_io_base")
+    CHECK_JSON_NULL(pci_mem32_base_json, "pci_mem32_base")
+    CHECK_JSON_NULL(pci_mem64_base_json, "pci_mem64_base")
+
     config->pci_config.ecam_base =
         strtoull(ecam_base_json->valuestring, NULL, 16);
     config->pci_config.io_base = strtoull(io_base_json->valuestring, NULL, 16);
@@ -289,65 +246,6 @@ static int parse_pci_config(cJSON *root, zone_config_t *config) {
         config->alloc_pci_devs[i] =
             cJSON_GetArrayItem(alloc_pci_devs_json, i)->valueint;
     }
-#endif
-
-#ifdef RISCV64
-    cJSON *ecam_base_json = cJSON_GetObjectItem(pci_config_json, "ecam_base");
-    cJSON *io_base_json = cJSON_GetObjectItem(pci_config_json, "io_base");
-    cJSON *pci_io_base_json =
-        cJSON_GetObjectItem(pci_config_json, "pci_io_base");
-    cJSON *mem32_base_json = cJSON_GetObjectItem(pci_config_json, "mem32_base");
-    cJSON *pci_mem32_base_json =
-        cJSON_GetObjectItem(pci_config_json, "pci_mem32_base");
-    cJSON *mem64_base_json = cJSON_GetObjectItem(pci_config_json, "mem64_base");
-    cJSON *pci_mem64_base_json =
-        cJSON_GetObjectItem(pci_config_json, "pci_mem64_base");
-    cJSON *ecam_size_json = cJSON_GetObjectItem(pci_config_json, "ecam_size");
-    cJSON *io_size_json = cJSON_GetObjectItem(pci_config_json, "io_size");
-    cJSON *mem32_size_json = cJSON_GetObjectItem(pci_config_json, "mem32_size");
-    cJSON *mem64_size_json = cJSON_GetObjectItem(pci_config_json, "mem64_size");
-
-    if (ecam_base_json == NULL || io_base_json == NULL ||
-        mem32_base_json == NULL || mem64_base_json == NULL ||
-        ecam_size_json == NULL || io_size_json == NULL ||
-        mem32_size_json == NULL || mem64_size_json == NULL ||
-        pci_io_base_json == NULL || pci_mem32_base_json == NULL ||
-        pci_mem64_base_json == NULL) {
-        fprintf(stderr, "Missing fields in pci_config.\n");
-        return -1;
-    }
-    config->pci_config.ecam_base =
-        strtoull(ecam_base_json->valuestring, NULL, 16);
-    config->pci_config.io_base = strtoull(io_base_json->valuestring, NULL, 16);
-    config->pci_config.mem32_base =
-        strtoull(mem32_base_json->valuestring, NULL, 16);
-    config->pci_config.mem64_base =
-        strtoull(mem64_base_json->valuestring, NULL, 16);
-    config->pci_config.pci_io_base =
-        strtoull(pci_io_base_json->valuestring, NULL, 16);
-    config->pci_config.pci_mem32_base =
-        strtoull(pci_mem32_base_json->valuestring, NULL, 16);
-    config->pci_config.pci_mem64_base =
-        strtoull(pci_mem64_base_json->valuestring, NULL, 16);
-    config->pci_config.ecam_size =
-        strtoull(ecam_size_json->valuestring, NULL, 16);
-    config->pci_config.io_size = strtoull(io_size_json->valuestring, NULL, 16);
-    config->pci_config.mem32_size =
-        strtoull(mem32_size_json->valuestring, NULL, 16);
-    config->pci_config.mem64_size =
-        strtoull(mem64_size_json->valuestring, NULL, 16);
-    cJSON *alloc_pci_devs_json = cJSON_GetObjectItem(root, "alloc_pci_devs");
-    int num_pci_devs = cJSON_GetArraySize(alloc_pci_devs_json);
-    config->num_pci_devs = num_pci_devs;
-    for (int i = 0; i < num_pci_devs; i++) {
-        config->alloc_pci_devs[i] =
-            cJSON_GetArrayItem(alloc_pci_devs_json, i)->valueint;
-    for (int i = 0; i < num_pci_devs; i++) {
-        config->alloc_pci_devs[i] =
-            cJSON_GetArrayItem(alloc_pci_devs_json, i)->valueint;
-    }
-#endif
-
 #endif
 
     return 0;
@@ -355,21 +253,26 @@ static int parse_pci_config(cJSON *root, zone_config_t *config) {
 
 static int zone_start_from_json(const char *json_config_path,
                                 zone_config_t *config) {
+    cJSON *root = NULL;
+
     FILE *file = fopen(json_config_path, "r");
     if (file == NULL) {
-        perror("Error opening file");
+        fprintf(stderr, "Error opening json file: %s\n", json_config_path);
         exit(1);
     }
     fseek(file, 0, SEEK_END);
     long file_size = ftell(file);
     fseek(file, 0, SEEK_SET);
     char *buffer = malloc(file_size + 1);
-    fread(buffer, 1, file_size, file);
+    if (fread(buffer, 1, file_size, file) == 0) {
+        fprintf(stderr, "Error reading json file: %s\n", json_config_path);
+        goto err_out;
+    }
     fclose(file);
     buffer[file_size] = '\0';
 
     // parse JSON
-    cJSON *root = cJSON_Parse(buffer);
+    root = cJSON_Parse(buffer);
     cJSON *zone_id_json = cJSON_GetObjectItem(root, "zone_id");
     cJSON *cpus_json = cJSON_GetObjectItem(root, "cpus");
     cJSON *name_json = cJSON_GetObjectItem(root, "name");
@@ -402,7 +305,6 @@ static int zone_start_from_json(const char *json_config_path,
     int num_cpus = cJSON_GetArraySize(cpus_json);
 
     for (int i = 0; i < num_cpus; i++) {
-    for (int i = 0; i < num_cpus; i++) {
         config->cpus |= (1 << cJSON_GetArrayItem(cpus_json, i)->valueint);
     }
 
@@ -411,37 +313,26 @@ static int zone_start_from_json(const char *json_config_path,
 
     if (num_memory_regions > CONFIG_MAX_MEMORY_REGIONS ||
         num_interrupts > CONFIG_MAX_INTERRUPTS) {
-    if (num_memory_regions > CONFIG_MAX_MEMORY_REGIONS ||
-        num_interrupts > CONFIG_MAX_INTERRUPTS) {
         fprintf(stderr, "Exceeded maximum allowed regions/interrupts.\n");
         goto err_out;
     }
 
     // Iterate through each memory region of the zone
     // Including memory and MMIO regions of the zone
-    // Iterate through each memory region of the zone
-    // Including memory and MMIO regions of the zone
     config->num_memory_regions = num_memory_regions;
-    for (int i = 0; i < num_memory_regions; i++) {
     for (int i = 0; i < num_memory_regions; i++) {
         cJSON *region = cJSON_GetArrayItem(memory_regions_json, i);
         memory_region_t *mem_region = &config->memory_regions[i];
 
         const char *type_str = cJSON_GetObjectItem(region, "type")->valuestring;
         if (strcmp(type_str, "ram") == 0) {
-        if (strcmp(type_str, "ram") == 0) {
             mem_region->type = MEM_TYPE_RAM;
-        } else if (strcmp(type_str, "io") == 0) {
-            // io device
         } else if (strcmp(type_str, "io") == 0) {
             // io device
             mem_region->type = MEM_TYPE_IO;
         } else if (strcmp(type_str, "virtio") == 0) {
             // virtio device
-        } else if (strcmp(type_str, "virtio") == 0) {
-            // virtio device
             mem_region->type = MEM_TYPE_VIRTIO;
-        } else {
         } else {
             printf("Unknown memory region type: %s\n", type_str);
             mem_region->type = -1; // invalid type
@@ -455,19 +346,7 @@ static int zone_start_from_json(const char *json_config_path,
                      NULL, 16);
         mem_region->size = strtoull(
             cJSON_GetObjectItem(region, "size")->valuestring, NULL, 16);
-        mem_region->physical_start =
-            strtoull(cJSON_GetObjectItem(region, "physical_start")->valuestring,
-                     NULL, 16);
-        mem_region->virtual_start =
-            strtoull(cJSON_GetObjectItem(region, "virtual_start")->valuestring,
-                     NULL, 16);
-        mem_region->size = strtoull(
-            cJSON_GetObjectItem(region, "size")->valuestring, NULL, 16);
 
-        log_debug("memory_region %d: type %d, physical_start %llx, "
-                  "virtual_start %llx, size %llx\n",
-                  i, mem_region->type, mem_region->physical_start,
-                  mem_region->virtual_start, mem_region->size);
         log_debug("memory_region %d: type %d, physical_start %llx, "
                   "virtual_start %llx, size %llx\n",
                   i, mem_region->type, mem_region->physical_start,
@@ -478,16 +357,11 @@ static int zone_start_from_json(const char *json_config_path,
     for (int i = 0; i < num_interrupts; i++) {
         config->interrupts[i] =
             cJSON_GetArrayItem(interrupts_json, i)->valueint;
-    for (int i = 0; i < num_interrupts; i++) {
-        config->interrupts[i] =
-            cJSON_GetArrayItem(interrupts_json, i)->valueint;
     }
 
     // ivc
-    // ivc
     int num_ivc_configs = cJSON_GetArraySize(ivc_configs_json);
     config->num_ivc_configs = num_ivc_configs;
-    for (int i = 0; i < num_ivc_configs; i++) {
     for (int i = 0; i < num_ivc_configs; i++) {
         cJSON *ivc_config_json = cJSON_GetArrayItem(ivc_configs_json, i);
         ivc_config_t *ivc_config = &config->ivc_configs[i];
@@ -512,28 +386,21 @@ static int zone_start_from_json(const char *json_config_path,
             cJSON_GetObjectItem(ivc_config_json, "interrupt_num")->valueint;
         ivc_config->max_peers =
             cJSON_GetObjectItem(ivc_config_json, "max_peers")->valueint;
-        log_debug("ivc_config %d: ivc_id %d, peer_id %d, shared_mem_ipa %llx, "
-                  "interrupt_num %d, max_peers %d\n",
-                  i, ivc_config->ivc_id, ivc_config->peer_id,
-                  ivc_config->shared_mem_ipa, ivc_config->interrupt_num,
-                  ivc_config->max_peers);
+        printf("ivc_config %d: ivc_id %d, peer_id %d, shared_mem_ipa %llx, "
+               "interrupt_num %d, max_peers %d\n",
+               i, ivc_config->ivc_id, ivc_config->peer_id,
+               ivc_config->shared_mem_ipa, ivc_config->interrupt_num,
+               ivc_config->max_peers);
     }
     config->entry_point = strtoull(entry_point_json->valuestring, NULL, 16);
 
     config->kernel_load_paddr =
         strtoull(kernel_load_paddr_json->valuestring, NULL, 16);
-    config->kernel_load_paddr =
-        strtoull(kernel_load_paddr_json->valuestring, NULL, 16);
 
-    config->dtb_load_paddr =
-        strtoull(dtb_load_paddr_json->valuestring, NULL, 16);
     config->dtb_load_paddr =
         strtoull(dtb_load_paddr_json->valuestring, NULL, 16);
 
     // Load kernel image to memory
-    config->kernel_size = load_image_to_memory(
-        kernel_filepath_json->valuestring,
-        strtoull(kernel_load_paddr_json->valuestring, NULL, 16));
     config->kernel_size = load_image_to_memory(
         kernel_filepath_json->valuestring,
         strtoull(kernel_load_paddr_json->valuestring, NULL, 16));
@@ -542,46 +409,46 @@ static int zone_start_from_json(const char *json_config_path,
     config->dtb_size = load_image_to_memory(
         dtb_filepath_json->valuestring,
         strtoull(dtb_load_paddr_json->valuestring, NULL, 16));
-    config->dtb_size = load_image_to_memory(
-        dtb_filepath_json->valuestring,
-        strtoull(dtb_load_paddr_json->valuestring, NULL, 16));
 
     // strncpy(config->kernel_args, kernel_args_json->valuestring,
     // CONFIG_KERNEL_ARGS_MAXLEN);
+
+    // check name length
+    if (strlen(name_json->valuestring) > CONFIG_NAME_MAXLEN) {
+        fprintf(stderr, "Zone name too long: %s\n", name_json->valuestring);
+        goto err_out;
+    }
     strncpy(config->name, name_json->valuestring, CONFIG_NAME_MAXLEN);
 
-    // Parse architecture-specific configurations (interrupts for each platform)
     // Parse architecture-specific configurations (interrupts for each platform)
     parse_arch_config(root, config);
 
     parse_pci_config(root, config);
 
-    cJSON_Delete(root); // delete cJSON object
-    free(buffer);
+    if (root)
+        cJSON_Delete(root);
+    if (buffer)
+        free(buffer);
 
-    int fd = open_dev_hvisor();
-    int fd = open_dev_hvisor();
+    int fd = open_dev();
     int err = ioctl(fd, HVISOR_ZONE_START, config);
-
 
     if (err)
         perror("zone_start: ioctl failed");
 
-
     close(fd);
-
 
     return 0;
 err_out:
-    cJSON_Delete(root);
-    free(buffer);
+    if (root)
+        cJSON_Delete(root);
+    if (buffer)
+        free(buffer);
     return -1;
 }
 
 // ./hvisor zone start <path_to_config_file>
 static int zone_start(int argc, char *argv[]) {
-    int zone_id;
-    char *json_config_path = NULL;
     int zone_id;
     char *json_config_path = NULL;
     zone_config_t config;
@@ -602,7 +469,7 @@ static int zone_shutdown(int argc, char *argv[]) {
     }
     __u64 zone_id;
     sscanf(argv[1], "%llu", &zone_id);
-    int fd = open_dev_hvisor();
+    int fd = open_dev();
     int err = ioctl(fd, HVISOR_ZONE_SHUTDOWN, zone_id);
     if (err)
         perror("zone_shutdown: ioctl failed");
@@ -617,9 +484,6 @@ static void print_cpu_list(__u64 cpu_mask, char *outbuf, size_t bufsize) {
     for (int i = 0; i < MAX_CPUS && buf - outbuf < bufsize; i++) {
         if ((cpu_mask & (1ULL << i)) != 0) {
             if (found_cpu) {
-    for (int i = 0; i < MAX_CPUS && buf - outbuf < bufsize; i++) {
-        if ((cpu_mask & (1ULL << i)) != 0) {
-            if (found_cpu) {
                 *buf++ = ',';
                 *buf++ = ' ';
             }
@@ -629,14 +493,11 @@ static void print_cpu_list(__u64 cpu_mask, char *outbuf, size_t bufsize) {
         }
     }
     if (!found_cpu) {
-    if (!found_cpu) {
         memcpy(outbuf, "none", 5);
     }
 }
 
 // ./hvisor zone list
-static int zone_list(int argc, char *argv[]) {
-    if (argc != 0) {
 static int zone_list(int argc, char *argv[]) {
     if (argc != 0) {
         help(1);
@@ -645,21 +506,18 @@ static int zone_list(int argc, char *argv[]) {
     zone_info_t *zones = malloc(sizeof(zone_info_t) * cnt);
     zone_list_args_t args = {cnt, zones};
     // printf("zone_list: cnt %llu, zones %p\n", cnt, zones);
-    int fd = open_dev_hvisor();
+    int fd = open_dev();
     int ret = ioctl(fd, HVISOR_ZONE_LIST, &args);
     if (ret < 0)
         perror("zone_list: ioctl failed");
 
     printf("| %11s     | %10s        | %9s       |\n", "zone_id", "cpus",
-    printf("| %11s     | %10s        | %9s       |\n", "zone_id", "cpus",
            "name");
 
-    for (int i = 0; i < ret; i++) {
     for (int i = 0; i < ret; i++) {
         char cpu_list_str[256]; // Assuming this buffer size is enough
         memset(cpu_list_str, 0, sizeof(cpu_list_str));
         print_cpu_list(zones[i].cpus, cpu_list_str, sizeof(cpu_list_str));
-        printf("| %15u | %17s | %15s |\n", zones[i].zone_id, cpu_list_str,
         printf("| %15u | %17s | %15s |\n", zones[i].zone_id, cpu_list_str,
                zones[i].name);
     }
@@ -669,7 +527,6 @@ static int zone_list(int argc, char *argv[]) {
 }
 
 int main(int argc, char *argv[]) {
-int main(int argc, char *argv[]) {
     int err = 0;
 
     if (argc < 2)
@@ -677,30 +534,20 @@ int main(int argc, char *argv[]) {
 
     if (strcmp(argv[1], "zone") == 0) {
         if (strcmp(argv[2], "start") == 0) {
-    if (strcmp(argv[1], "zone") == 0) {
-        if (strcmp(argv[2], "start") == 0) {
             err = zone_start(argc, argv);
-        } else if (strcmp(argv[2], "shutdown") == 0) {
         } else if (strcmp(argv[2], "shutdown") == 0) {
             err = zone_shutdown(argc - 3, &argv[3]);
         } else if (strcmp(argv[2], "list") == 0) {
             err = zone_list(argc - 3, &argv[3]);
         } else {
-        } else if (strcmp(argv[2], "list") == 0) {
-            err = zone_list(argc - 3, &argv[3]);
-        } else {
             help(1);
         }
-    } else if (strcmp(argv[1], "virtio") == 0) {
-        if (strcmp(argv[2], "start") == 0) {
     } else if (strcmp(argv[1], "virtio") == 0) {
         if (strcmp(argv[2], "start") == 0) {
             err = virtio_start(argc, argv);
         } else {
-        } else {
             help(1);
         }
-    } else {
     } else {
         help(1);
     }

--- a/tools/include/virtio.h
+++ b/tools/include/virtio.h
@@ -1,28 +1,34 @@
 #ifndef __HVISOR_VIRTIO_H
 #define __HVISOR_VIRTIO_H
-#include <stdint.h>
-#include <stdbool.h>
-#include <sys/uio.h>
-#include <linux/virtio_ring.h>
-#include <linux/virtio_mmio.h>
-#include <linux/virtio_config.h>
+#include "cJSON.h"
 #include "hvisor.h"
+#include <linux/virtio_config.h>
+#include <linux/virtio_mmio.h>
+#include <linux/virtio_ring.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <sys/uio.h>
 #include <unistd.h>
 
 #define VIRT_QUEUE_SIZE 512
 
 typedef struct VirtMmioRegs {
-    uint32_t device_id;
-    uint32_t dev_feature_sel;
-    uint32_t drv_feature_sel;
-    uint32_t queue_sel;
+    uint32_t device_id;       // Device type id, see VirtioDeviceType
+    uint32_t dev_feature_sel; // device_features_selection, the driver frontend
+                              // writes this register to obtain a group of
+                              // 32-bit device_features
+    uint32_t drv_feature_sel; // driver_features_selection, the driver frontend
+                              // writes this register to specify a group of
+                              // 32-bit activated device_features
+    uint32_t queue_sel; // The driver frontend writes this register to select
+                        // which virtqueue to use
     uint32_t interrupt_status;
-    // interrupt_count doesn't exist in virtio specifiction, 
+    // interrupt_count doesn't exist in virtio specification,
     // only used for ensuring the correctness of interrupt_status.
-    uint32_t interrupt_count; 
+    uint32_t interrupt_count;
     uint32_t status;
     uint32_t generation;
-    uint64_t dev_feature;
+    uint64_t dev_feature; // device_features
     uint64_t drv_feature;
 } VirtMmioRegs;
 
@@ -30,8 +36,12 @@ typedef enum {
     VirtioTNone,
     VirtioTNet,
     VirtioTBlock,
-    VirtioTConsole
+    VirtioTConsole,
+    VirtioTGPU = 16
 } VirtioDeviceType;
+
+// Convert VirtioDeviceType to const char *
+const char *virtio_device_type_to_string(VirtioDeviceType type);
 
 typedef struct vring_desc VirtqDesc;
 typedef struct vring_avail VirtqAvail;
@@ -44,52 +54,100 @@ struct VirtQueue;
 typedef struct VirtQueue VirtQueue;
 
 struct VirtQueue {
-    VirtIODevice *dev;
-    uint64_t vq_idx;
-    uint64_t num; // queue size. elements number
-    uint32_t queue_num_max;
+    VirtIODevice *dev; // The device which the virtqueue belongs to
+    uint64_t vq_idx;   // Index of the virtqueue
+    uint64_t
+        num; // The capacity of the virtqueue determined by the driver frontend
+    uint32_t queue_num_max; // The maximum capacity of the virtqueue, informed
+                            // by the backend
 
-    uint64_t desc_table_addr;
-    uint64_t avail_addr;
-    uint64_t used_addr;
+    uint64_t desc_table_addr; // Descriptor table address (physical address set
+                              // by zonex)
+    uint64_t
+        avail_addr; // Available ring address (physical address set by zonex)
+    uint64_t used_addr; // Used ring address (physical address set by zonex)
 
-    volatile VirtqDesc *desc_table;
-    volatile VirtqAvail *avail_ring;
-    volatile VirtqUsed *used_ring;
-    int (*notify_handler)(VirtIODevice *vdev, VirtQueue *vq);
+    // Obtained by get_virt_addr
+    volatile VirtqDesc
+        *desc_table; // Descriptor table (physical address set by zone0)
+    volatile VirtqAvail
+        *avail_ring; // Available ring (physical address set by zone0)
+    volatile VirtqUsed *used_ring; // Used ring (physical address set by zone0)
+    int (*notify_handler)(
+        VirtIODevice *vdev,
+        VirtQueue *vq); // Called when the virtqueue has requests to process
 
-    uint16_t last_avail_idx;
-    uint16_t last_used_idx;
-    uint16_t used_flags;
+    uint16_t last_avail_idx; // The tail idx of the available ring during the
+                             // last processing (tail/newest request idx)
+    uint16_t last_used_idx;  // The tail idx of the used ring during the last
+                             // processing (tail/newest response idx)
 
-    uint8_t ready;
-	uint8_t event_idx_enabled;
-	pthread_mutex_t used_ring_lock;
+    uint8_t ready;             // Whether it is ready
+    uint8_t event_idx_enabled; // Whether the VIRTIO_RING_F_EVENT_IDX feature is
+                               // enabled This feature allows the device to
+                               // record the current position of the element on
+                               // the Avail Ring being processed in the last
+                               // element of the Used Ring, thereby informing
+                               // the frontend driver of the backend processing
+                               // progress Enabling this feature will change the
+                               // flags field of the avail_ring
+    pthread_mutex_t used_ring_lock; // Used ring lock
 };
-// The highest representations of virtio device
-struct VirtIODevice
-{
-    uint32_t id;
-    uint32_t vqs_len;
-    uint32_t zone_id;
-    uint32_t irq_id;
-    uint64_t base_addr; // the virtio device's base addr in non root zone's memory
-    uint64_t len;       // mmio region's length
-    VirtioDeviceType type;
-    VirtMmioRegs regs;
-    VirtQueue *vqs;
-    void *dev;          // according to device type, blk is BlkDev, net is NetDev, console is ConsoleDev
-    void (*virtio_close)(VirtIODevice *vdev);
-    bool activated;
+
+// The highest abstruct representations of virtio device
+struct VirtIODevice {
+    uint32_t vqs_len; // Number of virtqueues
+    uint32_t zone_id; // ID of the zone to which it belongs, initialized in
+                      // create_virtio_device
+    uint32_t irq_id; // Device interrupt ID, initialized in create_virtio_device
+    uint64_t base_addr; // The virtio device's base address in non-root zone's
+                        // memory, initialized in create_virtio_device
+    uint64_t
+        len; // Length of the mmio region, initialized in create_virtio_device
+    VirtioDeviceType type; // Device type, initialized in create_virtio_device
+    VirtMmioRegs regs;     // MMIO registers of the device
+                           // Initialized in create_virtio_device, subsequently
+                           // negotiated by the driver frontend
+    VirtQueue *vqs;        // Array of virtqueues of the device, initialized in
+                           // init_virtio_queue
+    void
+        *dev; // According to device type, blk is BlkDev, net is NetDev, console
+              // is ConsoleDev Pointer to the specific device's special config
+    void (*virtio_close)(
+        VirtIODevice *vdev); // Function called when closing the virtio device
+    bool activated;          // Whether the current virtio device is activated
 };
+
 // used event idx for driver telling device when to notify driver.
 #define VQ_USED_EVENT(vq) ((vq)->avail_ring->ring[(vq)->num])
 // avail event idx for device telling driver when to notify device.
 #define VQ_AVAIL_EVENT(vq) (*(__uint16_t *)&(vq)->used_ring->ring[(vq)->num])
 
 #define VIRT_MAGIC 0x74726976 /* 'virt' */
+
 #define VIRT_VERSION 2
+
 #define VIRT_VENDOR 0x48564953 /* 'HVIS' */
+
+// Set net and console to non-blocking
+int set_nonblocking(int fd);
+
+int get_zone_ram_index(void *zonex_ipa, int zone_id);
+
+/// Check if circular queue is full. size must be a power of 2
+int is_queue_full(unsigned int front, unsigned int rear, unsigned int size);
+
+int is_queue_empty(unsigned int front, unsigned int rear);
+
+void write_barrier(void);
+
+void read_barrier(void);
+
+void rw_barrier(void);
+
+VirtIODevice *create_virtio_device(VirtioDeviceType dev_type, uint32_t zone_id,
+                                   uint64_t base_addr, uint64_t len,
+                                   uint32_t irq_id, void *arg0, void *arg1);
 
 void init_virtio_queue(VirtIODevice *vdev, VirtioDeviceType type);
 
@@ -104,22 +162,53 @@ bool virtqueue_is_empty(VirtQueue *vq);
 // uint16_t virtqueue_pop_desc_chain_head(VirtQueue *vq);
 
 void virtqueue_disable_notify(VirtQueue *vq);
+
 void virtqueue_enable_notify(VirtQueue *vq);
 
 bool desc_is_writable(volatile VirtqDesc *desc_table, uint16_t idx);
+
+void *get_virt_addr(void *zonex_ipa, int zone_id);
+
+void virtqueue_set_avail(VirtQueue *vq);
+
+void virtqueue_set_used(VirtQueue *vq);
+
+int descriptor2iov(int i, volatile VirtqDesc *vd, struct iovec *iov,
+                   uint16_t *flags, int zone_id, bool copy_flags);
+
 int process_descriptor_chain(VirtQueue *vq, uint16_t *desc_idx,
-                struct iovec **iov, uint16_t **flags, int append_len);
+                             struct iovec **iov, uint16_t **flags,
+                             int append_len, bool copy_flags);
+
 void update_used_ring(VirtQueue *vq, uint16_t idx, uint32_t iolen);
-void virtio_inject_irq(VirtQueue *vq);
+
+uint64_t virtio_mmio_read(VirtIODevice *vdev, uint64_t offset, unsigned size);
+
+void virtio_mmio_write(VirtIODevice *vdev, uint64_t offset, uint64_t value,
+                       unsigned size);
+
+bool in_range(uint64_t value, uint64_t lower, uint64_t len);
+
+void virtio_inject_irq(VirtQueue *vq); // unused
+
+void virtio_finish_cfg_req(uint32_t target_cpu, uint64_t value);
+
+int virtio_handle_req(volatile struct device_req *req);
+
+void virtio_close();
+
 void handle_virtio_requests();
+
+void initialize_log();
+
 int virtio_init();
+
+int create_virtio_device_from_json(cJSON *device_json, int zone_id);
+
+int virtio_start_from_json(char *json_path);
+
 int virtio_start(int argc, char *argv[]);
 
-/// check circular queue is full. size must be a power of 2
-int is_queue_full(unsigned int front, unsigned int rear, unsigned int size);
-int is_queue_empty(unsigned int front, unsigned int rear);
+void *read_file(char *filename, u_int64_t *filesize);
 
-int set_nonblocking(int fd);
-void* read_file(const char* filename, __u64* filesize);
 #endif /* __HVISOR_VIRTIO_H */
-

--- a/tools/include/virtio_gpu.h
+++ b/tools/include/virtio_gpu.h
@@ -1,0 +1,390 @@
+#ifndef _HVISOR_VIRTIO_GPU_H
+#define _HVISOR_VIRTIO_GPU_H
+#include "bits/pthreadtypes.h"
+#include "linux/types.h"
+#include "sys/queue.h"
+#include "virtio.h"
+#include <linux/virtio_gpu.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+#include <xf86drm.h>
+#include <xf86drmMode.h>
+
+/*********************************************************************
+    Macro Definitions
+ */
+// controlq index
+#define GPU_CONTROL_QUEUE 0
+
+// cursorq index
+#define GPU_CURSOR_QUEUE 1
+
+// Number of virtqueues
+#define GPU_MAX_QUEUES 2
+
+// Maximum number of elements in a virtqueue
+#define VIRTQUEUE_GPU_MAX_SIZE 256
+
+// Kick the frontend immediately after processing more than this number of
+// requests
+#define VIRTIO_GPU_MAX_REQUEST_BEFORE_KICK 16
+
+// Maximum number of scanouts supported by hvisor's virtio_gpu implementation
+#define HVISOR_VIRTIO_GPU_MAX_SCANOUTS 1
+
+// Maximum memory used for storing resources by a virtio gpu device
+#define VIRTIO_GPU_MAX_HOSTMEM 536870912 // 512MB
+
+// Supported virtio features
+// Optional VIRTIO_RING_F_INDIRECT_DESC and VIRTIO_RING_F_EVENT_IDX
+// Pending support for VIRTIO_GPU_F_EDID, VIRTIO_GPU_F_RESOURCE_UUID,
+// VIRTIO_GPU_F_RESOURCE_BLOB, VIRTIO_GPU_F_VIRGL, VIRTIO_GPU_F_CONTEXT_INIT
+#define GPU_SUPPORTED_FEATURES                                                 \
+    ((1ULL << VIRTIO_F_VERSION_1) | VIRTIO_RING_F_INDIRECT_DESC)
+
+// Default configuration for scanout[0]
+#define SCANOUT_DEFAULT_WIDTH 1280
+
+#define SCANOUT_DEFAULT_HEIGHT 800
+
+// Macro to find the minimum value
+#define MIN(a, b) ((a) < (b) ? (a) : (b))
+
+// Conversion between virtio_gpu_formats and drm formats
+#define VIRTIO_GPU_FORMAT_TO_DRM_FORMAT(format)                                \
+    ((format == VIRTIO_GPU_FORMAT_X8R8G8B8_UNORM)   ? DRM_FORMAT_XRGB8888      \
+     : (format == VIRTIO_GPU_FORMAT_X8B8G8R8_UNORM) ? DRM_FORMAT_XBGR8888      \
+     : (format == VIRTIO_GPU_FORMAT_R8G8B8X8_UNORM) ? DRM_FORMAT_RGBX8888      \
+     : (format == VIRTIO_GPU_FORMAT_B8G8R8X8_UNORM) ? DRM_FORMAT_BGRX8888      \
+     : (format == VIRTIO_GPU_FORMAT_A8R8G8B8_UNORM) ? DRM_FORMAT_ARGB8888      \
+     : (format == VIRTIO_GPU_FORMAT_A8B8G8R8_UNORM) ? DRM_FORMAT_ABGR8888      \
+     : (format == VIRTIO_GPU_FORMAT_R8G8B8A8_UNORM) ? DRM_FORMAT_RGBA8888      \
+     : (format == VIRTIO_GPU_FORMAT_B8G8R8A8_UNORM) ? DRM_FORMAT_BGRA8888      \
+                                                    : 0 /* Unknown format */)
+
+/*********************************************************************
+    Structures
+ */
+// virtio_gpu_config as follows
+// #define VIRTIO_GPU_EVENT_DISPLAY (1 << 0)
+// struct virtio_gpu_config {
+// 	__u32 events_read;  // Events waiting to be read by the driver
+// (VIRTIO_GPU_EVENT_DISPLAY)
+// 	__u32 events_clear; // Clear waiting events in the driver
+// 	__u32 num_scanouts; // Maximum number of supported scanouts, see related
+// macro definition VIRTIO_GPU_MAX_SCANOUTS
+// 	__u32 num_capsets;  // Device's capability sets, see related macro
+// definition VIRTIO_GPU_CAPSET_*
+// };
+
+// Clear events
+// events_read &= ~events_clear
+
+typedef struct virtio_gpu_config GPUConfig;
+typedef struct virtio_gpu_ctrl_hdr GPUControlHeader;
+typedef struct virtio_gpu_update_cursor GPUUpdateCursor;
+
+// Resource object stored in memory during rendering (e.g., images)
+// When in use, it needs to be converted from iov to a drm_mode_create_dumb
+// object for output
+typedef struct virtio_gpu_simple_resource {
+    uint32_t resource_id;   // Resource ID
+    uint32_t width, height; // Resource width and height
+    uint32_t format; // Resource format, combined with width and height to
+                     // calculate the memory size used by the resource
+    // addrs is an array of physical addresses of the resource in the guest, as
+    // zonex will directly map to the virtual memory space of hvisor-tool, this
+    // field is temporarily not needed uint64_t *addrs;
+    struct iovec *iov; // Use iov to store the resource
+    unsigned int iov_cnt;
+    uint64_t hostmem;         // Size of the resource in the host
+    uint32_t scanout_bitmask; // Marks which scanout the resource is used by
+    struct virtio_gpu_rect
+        transfer_rect; // In transfer_to_2d, determines which part of the image
+                       // in guest memory to flush
+    uint64_t transfer_offset;
+    TAILQ_ENTRY(virtio_gpu_simple_resource) next;
+} GPUSimpleResource;
+
+typedef struct virtio_gpu_framebuffer {
+    // TODO: Double buffering
+    uint32_t fb_id; // Framebuffer ID
+    // TODO: Format
+    // The format mainly determines how many bytes each pixel occupies
+    // The formats provided by virtio_gpu_formats are all 4 bytes per pixel
+    uint32_t format;        // virtio_gpu_formats
+    uint32_t bytes_pp;      // Bytes per pixel
+    uint32_t width, height; // Framebuffer width and height
+    uint32_t stride; // Stride refers to the number of bytes each row of the
+                     // image occupies in memory, stride * height equals the
+                     // total number of bytes (hostmem)
+    uint32_t offset;
+    // drm related
+    uint32_t drm_dumb_size;   // Buffer size
+    uint32_t drm_dumb_handle; // Handle pointing to the drm framebuffer
+    void *fb_addr;            // Virtual address of the buffer in this process
+    bool enabled;             // Whether the buffer is enabled
+} GPUFrameBuffer;
+
+// 32-bit RGBA
+typedef struct hvisor_cursor {
+    uint16_t width, height;
+    int hot_x, hot_y;
+    int refcount;
+    uint32_t data[];
+} HvCursor;
+
+// Settings related to the actual display device
+typedef struct virtio_gpu_scanout {
+    uint32_t width, height;
+    uint32_t x, y;
+    uint32_t resource_id;
+    GPUUpdateCursor cursor;
+    HvCursor *current_cursor;
+    GPUFrameBuffer frame_buffer;
+    // Output card used
+    int card0_fd;
+    // drm related
+    drmModeCrtc *crtc;
+    drmModeEncoder *encoder;
+    drmModeConnector *connector;
+} GPUScanout;
+
+// Settings of the display device specified by json
+typedef struct virtio_gpu_requested_state {
+    uint32_t width, height;
+    int x, y;
+} GPURequestedState;
+
+// GPU device structure
+typedef struct virtio_gpu_dev {
+    GPUConfig config;
+    // TODO: Initialize scanouts
+    // Pre-allocated scanouts owned by virtio gpu
+    GPUScanout scanouts[HVISOR_VIRTIO_GPU_MAX_SCANOUTS];
+    // TODO: Initialize requested_state
+    // Requested states negotiated by these scanouts
+    GPURequestedState requested_states[HVISOR_VIRTIO_GPU_MAX_SCANOUTS];
+    // Resources owned by virtio gpu
+    TAILQ_HEAD(, virtio_gpu_simple_resource) resource_list;
+    // Command queue for async processing by virtio gpu
+    TAILQ_HEAD(, virtio_gpu_control_cmd) command_queue;
+    // Number of scanouts
+    int scanouts_num;
+    // Total memory occupied by the virtio device
+    uint64_t hostmem;
+    // Enabled scanout
+    int enabled_scanout_bitmask;
+    // async
+    pthread_t gpu_thread;
+    pthread_cond_t gpu_cond;
+    pthread_mutex_t queue_mutex;
+    bool close;
+} GPUDev;
+
+typedef struct virtio_gpu_control_cmd {
+    GPUControlHeader control_header;
+    struct iovec *resp_iov;    // iov to write the response
+    unsigned int resp_iov_cnt; // Number of iovs
+    uint16_t
+        resp_idx;   // Used index corresponding to the request after completion
+    bool finished;  // Indicates whether the current cmd is completed after
+                    // processing, if not, use no_data response uniformly
+    uint32_t error; // Error type
+    uint32_t from_queue; // Queue from which the request came
+    TAILQ_ENTRY(virtio_gpu_control_cmd) next; // Next cmd in the command queue
+} GPUCommand;
+
+/*********************************************************************
+  virtio_gpu_base.c
+ */
+// Initialize GPUDev structure
+GPUDev *init_gpu_dev(GPURequestedState *requested_states);
+
+// Initialize virtio-gpu device
+int virtio_gpu_init(VirtIODevice *vdev);
+
+// Close virtio-gpu device
+void virtio_gpu_close(VirtIODevice *vdev);
+
+// Reset virtio-gpu device
+void virtio_gpu_reset();
+
+// Handler function when controlq has requests to process
+int virtio_gpu_ctrl_notify_handler(VirtIODevice *vdev, VirtQueue *vq);
+
+// Handler function when cursorq has requests to process
+int virtio_gpu_cursor_notify_handler(VirtIODevice *vdev, VirtQueue *vq);
+
+// Process a single request
+int virtio_gpu_handle_single_request(VirtIODevice *vdev, VirtQueue *vq,
+                                     uint32_t from);
+
+// Copy request control structure from iov
+#define VIRTIO_GPU_FILL_CMD(iov, iov_cnt, out)                                 \
+    do {                                                                       \
+        size_t virtiogpufillcmd_s_ =                                           \
+            iov_to_buf(iov, iov_cnt, 0, &(out), sizeof(out));                  \
+        if (virtiogpufillcmd_s_ != sizeof(out)) {                              \
+            log_error("cannot fill virtio gpu command with input!");           \
+            return;                                                            \
+        }                                                                      \
+    } while (0)
+
+// Copy arbitrary size from iov to buffer
+size_t iov_to_buf_full(const struct iovec *iov, unsigned int iov_cnt,
+                       size_t offset, void *buf, size_t bytes_need_copy);
+
+// Copy arbitrary size from buffer to iov
+size_t buf_to_iov_full(const struct iovec *iov, unsigned int iov_cnt,
+                       size_t offset, const void *buf, size_t bytes_need_copy);
+
+// Fill buffer from iov
+// Often used when only a field in the command structure is needed, or when the
+// vq length is only 2 Therefore, optimization is needed when copying can be
+// completed in only one buffer of the iov
+static inline size_t iov_to_buf(const struct iovec *iov, // NOLINT
+                                const unsigned int iov_cnt, size_t offset,
+                                void *buf, size_t bytes_need_copy) {
+    if (__builtin_constant_p(bytes_need_copy) && iov_cnt &&
+        offset <= iov[0].iov_len &&
+        bytes_need_copy <= iov[0].iov_len - offset) {
+        // If the copy operation can be completed in the first buffer of the iov
+        // Copy and return immediately
+        memcpy(buf, (char *)iov[0].iov_base + offset, bytes_need_copy);
+        return bytes_need_copy;
+    }
+    // Need to copy from multiple buffers of the iov
+    return iov_to_buf_full(iov, iov_cnt, offset, buf, bytes_need_copy);
+}
+
+// Fill iov from buffer, single optimization
+static inline size_t buf_to_iov(const struct iovec *iov, // NOLINT
+                                unsigned int iov_cnt, size_t offset,
+                                const void *buf, size_t bytes_need_copy) {
+    if (__builtin_constant_p(bytes_need_copy) && iov_cnt &&
+        offset <= iov[0].iov_len &&
+        bytes_need_copy <= iov[0].iov_len - offset) {
+        memcpy((char *)iov[0].iov_base + offset, buf, bytes_need_copy);
+        return bytes_need_copy;
+    }
+    return buf_to_iov_full(iov, iov_cnt, offset, buf, bytes_need_copy);
+}
+
+/*********************************************************************
+  virtio_gpu.c
+ */
+// Return response with data
+void virtio_gpu_ctrl_response(VirtIODevice *vdev, GPUCommand *gcmd,
+                              GPUControlHeader *resp, size_t resp_len);
+
+// Return response without data
+void virtio_gpu_ctrl_response_nodata(VirtIODevice *vdev, GPUCommand *gcmd,
+                                     enum virtio_gpu_ctrl_type type);
+
+// Corresponding to VIRTIO_GPU_CMD_GET_DISPLAY_INFO
+// Return current output configuration
+void virtio_gpu_get_display_info(VirtIODevice *vdev, GPUCommand *gcmd);
+
+// Corresponding to VIRTIO_GPU_CMD_GET_EDID
+// Return current EDID information
+void virtio_gpu_get_edid(VirtIODevice *vdev, GPUCommand *gcmd);
+
+// Corresponding to VIRTIO_GPU_CMD_RESOURCE_CREATE_2D
+// Create a 2D resource on the host with the given id, width, height, and format
+// from the guest
+void virtio_gpu_resource_create_2d(VirtIODevice *vdev, GPUCommand *gcmd);
+
+// Check if the given virtio gpu device has a resource with the id resource_id
+// If not, return NULL
+GPUSimpleResource *virtio_gpu_find_resource(GPUDev *gdev, uint32_t resource_id);
+
+// Check if the resource with the specified id is already bound, if so, return
+// its pointer Otherwise, if there is no resource corresponding to the id, or
+// the resource is not bound, return NULL
+GPUSimpleResource *virtio_gpu_check_resource(VirtIODevice *vdev,
+                                             uint32_t resource_id,
+                                             const char *caller,
+                                             uint32_t *error);
+
+// Calculate the memory size occupied by the resource in the host
+uint32_t calc_image_hostmem(int bits_per_pixel, uint32_t width,
+                            uint32_t height);
+
+// Corresponding to VIRTIO_GPU_CMD_RESOURCE_UNREF
+// Destroy a resource
+void virtio_gpu_resource_unref(VirtIODevice *vdev, GPUCommand *gcmd);
+
+// Destroy the specified resource
+void virtio_gpu_resource_destory(GPUDev *gdev, GPUSimpleResource *res);
+
+// Unregister the resource of the given scanout, making the scanout invalid
+void virtio_gpu_disable_scanout(GPUDev *gdev, int scanout_id);
+
+// Clear the mapping of the resource
+void virtio_gpu_cleanup_mapping(GPUDev *gdev, GPUSimpleResource *res);
+
+// Corresponding to VIRTIO_GPU_CMD_RESOURCE_FLUSH
+// Flush a resource that is linked to a scanout
+void virtio_gpu_resource_flush(VirtIODevice *vdev, GPUCommand *gcmd);
+
+// Create a drm_framebuffer for the scanout
+void virtio_gpu_create_drm_framebuffer(GPUScanout *scanout, uint32_t *error);
+
+// Copy the resource to the scanout's drm_framebuffer and flush
+void virtio_gpu_copy_and_flush(GPUScanout *scanout, GPUSimpleResource *res,
+                               uint32_t *error);
+
+// Remove the drm_framebuffer of the scanout
+void virtio_gpu_remove_drm_framebuffer(GPUScanout *scanout);
+
+// Corresponding to VIRTIO_GPU_CMD_SET_SCANOUT
+// Set the display parameters of the scanout and bind the resource to the
+// scanout
+void virtio_gpu_set_scanout(VirtIODevice *vdev, GPUCommand *gcmd);
+
+// Specifically set the scanout according to the parameters
+bool virtio_gpu_do_set_scanout(VirtIODevice *vdev, uint32_t scanout_id,
+                               GPUFrameBuffer *fb, GPUSimpleResource *res,
+                               struct virtio_gpu_rect *r, uint32_t *error);
+
+// Update the scanout
+void virtio_gpu_update_scanout(VirtIODevice *vdev, uint32_t scanout_id,
+                               GPUFrameBuffer *fb, GPUSimpleResource *res,
+                               struct virtio_gpu_rect *r);
+
+// Corresponding to VIRTIO_GPU_CMD_TRANSFER_TO_HOST_2D
+// Transfer the content in guest memory to the resource in the host
+void virtio_gpu_transfer_to_host_2d(VirtIODevice *vdev, GPUCommand *gcmd);
+
+// Corresponding to VIRTIO_GPU_CMD_RESOURCE_ATTACH_BACKING
+// Bind multiple memory regions in the guest to the resource (as backing
+// storage)
+void virtio_gpu_resource_attach_backing(VirtIODevice *vdev, GPUCommand *gcmd);
+
+// Map guest memory to host's iov
+int virtio_gpu_create_mapping_iov(VirtIODevice *vdev, uint32_t nr_entries,
+                                  uint32_t offset,
+                                  GPUCommand *gcmd, /*uint64_t **addr,*/
+                                  struct iovec **iov, uint32_t *niov);
+
+// ! reserved
+// Clear mapping
+// void virtio_gpu_cleanup_mapping_iov(GPUDev *gdev, struct iovec *iov,
+//                                     uint32_t iov_cnt);
+
+// Corresponding to VIRTIO_GPU_CMD_RESOURCE_DETACH_BACKING
+// Unbind the memory regions in the guest from the resource
+void virtio_gpu_resource_detach_backing(VirtIODevice *vdev, GPUCommand *gcmd);
+
+// Process the request according to the control header
+void virtio_gpu_simple_process_cmd(GPUCommand *gcmd, VirtIODevice *vdev);
+
+/*********************************************************************
+  virtio_gpu_async.c
+ */
+// Processing thread
+void *virtio_gpu_handler(void *vdev);
+
+#endif /* _HVISOR_VIRTIO_GPU_H */

--- a/tools/log.c
+++ b/tools/log.c
@@ -25,190 +25,154 @@
 
 #define MAX_CALLBACKS 32
 
-typedef struct
-{
-	log_LogFn fn;
-	void *udata;
-	int level;
+typedef struct {
+    log_LogFn fn;
+    void *udata;
+    int level;
 } Callback;
 
-static struct
-{
-	void *udata;
-	log_LockFn lock;
-	int level;
-	bool quiet;
-	Callback callbacks[MAX_CALLBACKS];
+static struct {
+    void *udata;
+    log_LockFn lock;
+    int level;
+    bool quiet;
+    Callback callbacks[MAX_CALLBACKS];
 } L;
 
-static const char *level_strings[] = {
-	"TRACE", "DEBUG", "INFO", "WARN", "ERROR", "FATAL"};
+static const char *level_strings[] = {"TRACE", "DEBUG", "INFO",
+                                      "WARN",  "ERROR", "FATAL"};
 
 #ifdef LOG_USE_COLOR
-static const char *level_colors[] = {
-	"\x1b[94m", "\x1b[36m", "\x1b[32m", "\x1b[33m", "\x1b[31m", "\x1b[35m"};
+static const char *level_colors[] = {"\x1b[94m", "\x1b[36m", "\x1b[32m",
+                                     "\x1b[33m", "\x1b[31m", "\x1b[35m"};
 #endif
 
-static void stdout_callback(log_Event *ev, int with_enter)
-{
-	char buf[16];
-	// put ev->time as a string into buf
-	buf[strftime(buf, sizeof(buf), "%H:%M:%S", ev->time)] = '\0';
-	
-	if (with_enter) {
-	#ifdef LOG_USE_COLOR
-		fprintf(
-			ev->udata, "%s %s%-5s\x1b[0m \x1b[90m%s:%d:\x1b[0m ",
-			buf, level_colors[ev->level], level_strings[ev->level],
-			ev->file, ev->line);
-	#else
-		fprintf(
-			ev->udata, "%s %-5s %s:%d: ",
-			buf, level_strings[ev->level], ev->file, ev->line);
-	#endif
-	}
+static void stdout_callback(log_Event *ev, int with_enter) {
+    char buf[16];
+    // put ev->time as a string into buf
+    buf[strftime(buf, sizeof(buf), "%H:%M:%S", ev->time)] = '\0';
 
-	vfprintf(ev->udata, ev->fmt, ev->ap);
-	if (with_enter)
-		fprintf(ev->udata, "\n");
-	fflush(ev->udata);
+    if (with_enter) {
+#ifdef LOG_USE_COLOR
+        fprintf(ev->udata, "%s %s%-5s\x1b[0m \x1b[90m%s:%d:\x1b[0m ", buf,
+                level_colors[ev->level], level_strings[ev->level], ev->file,
+                ev->line);
+#else
+        fprintf(ev->udata, "%s %-5s %s:%d: ", buf, level_strings[ev->level],
+                ev->file, ev->line);
+#endif
+    }
+
+    vfprintf(ev->udata, ev->fmt, ev->ap);
+    if (with_enter)
+        fprintf(ev->udata, "\n");
+    fflush(ev->udata);
 }
 
-static void file_callback(log_Event *ev)
-{
-	char buf[64];
-	buf[strftime(buf, sizeof(buf), "%Y-%m-%d %H:%M:%S", ev->time)] = '\0';
-	fprintf(
-		ev->udata, "%s %-5s %s:%d: ",
-		buf, level_strings[ev->level], ev->file, ev->line);
-	vfprintf(ev->udata, ev->fmt, ev->ap);
-	fprintf(ev->udata, "\n");
-	fflush(ev->udata);
+static void file_callback(log_Event *ev) {
+    char buf[64];
+    buf[strftime(buf, sizeof(buf), "%Y-%m-%d %H:%M:%S", ev->time)] = '\0';
+    fprintf(ev->udata, "%s %-5s %s:%d: ", buf, level_strings[ev->level],
+            ev->file, ev->line);
+    vfprintf(ev->udata, ev->fmt, ev->ap);
+    fprintf(ev->udata, "\n");
+    fflush(ev->udata);
 }
 
-static void lock(void)
-{
-	if (L.lock)
-	{
-		L.lock(true, L.udata);
-	}
+static void lock(void) {
+    if (L.lock) {
+        L.lock(true, L.udata);
+    }
 }
 
-static void unlock(void)
-{
-	if (L.lock)
-	{
-		L.lock(false, L.udata);
-	}
+static void unlock(void) {
+    if (L.lock) {
+        L.lock(false, L.udata);
+    }
 }
 
-const char *log_level_string(int level)
-{
-	return level_strings[level];
+const char *log_level_string(int level) { return level_strings[level]; }
+
+void log_set_lock(log_LockFn fn, void *udata) {
+    L.lock = fn;
+    L.udata = udata;
 }
 
-void log_set_lock(log_LockFn fn, void *udata)
-{
-	L.lock = fn;
-	L.udata = udata;
+void log_set_level(int level) { L.level = level; }
+
+void log_set_quiet(bool enable) { L.quiet = enable; }
+
+int log_add_callback(log_LogFn fn, void *udata, int level) {
+    for (int i = 0; i < MAX_CALLBACKS; i++) {
+        if (!L.callbacks[i].fn) {
+            L.callbacks[i] = (Callback){fn, udata, level};
+            return 0;
+        }
+    }
+    return -1;
 }
 
-void log_set_level(int level)
-{
-	L.level = level;
+int log_add_fp(FILE *fp, int level) {
+    return log_add_callback(file_callback, fp, level);
 }
 
-void log_set_quiet(bool enable)
-{
-	L.quiet = enable;
+static void init_event(log_Event *ev, void *udata) {
+    if (!ev->time) {
+        time_t t = time(NULL);
+        ev->time = localtime(&t);
+    }
+    ev->udata = udata;
 }
 
-int log_add_callback(log_LogFn fn, void *udata, int level)
-{
-	for (int i = 0; i < MAX_CALLBACKS; i++)
-	{
-		if (!L.callbacks[i].fn)
-		{
-			L.callbacks[i] = (Callback){fn, udata, level};
-			return 0;
-		}
-	}
-	return -1;
-}
+void log_log(int with_enter, int level, const char *file, int line,
+             const char *fmt, ...) {
+    if (L.quiet || level < L.level) {
+        return;
+    }
 
-int log_add_fp(FILE *fp, int level)
-{
-	return log_add_callback(file_callback, fp, level);
-}
+    log_Event ev = {
+        .fmt = fmt,
+        .file = file,
+        .line = line,
+        .level = level,
+    };
 
-static void init_event(log_Event *ev, void *udata)
-{
-	if (!ev->time)
-	{
-		time_t t = time(NULL);
-		ev->time = localtime(&t);
-	}
-	ev->udata = udata;
-}
+    lock();
 
-void log_log(int with_enter, int level, const char *file, int line, const char *fmt, ...)
-{
-	if (L.quiet || level < L.level)
-	{
-		return;
-	}
+    if (!L.quiet && level >= L.level) {
+        init_event(&ev, stderr);
+        va_start(ev.ap, fmt);
+        stdout_callback(&ev, with_enter);
+        va_end(ev.ap);
+    }
 
-	log_Event ev = {
-		.fmt = fmt,
-		.file = file,
-		.line = line,
-		.level = level,
-	};
+    for (int i = 0; i < MAX_CALLBACKS && L.callbacks[i].fn; i++) {
+        Callback *cb = &L.callbacks[i];
+        if (level >= cb->level) {
+            init_event(&ev, cb->udata);
+            va_start(ev.ap, fmt);
+            cb->fn(&ev);
+            va_end(ev.ap);
+        }
+    }
 
-	lock();
-
-	if (!L.quiet && level >= L.level)
-	{
-		init_event(&ev, stderr);
-		va_start(ev.ap, fmt);
-		stdout_callback(&ev, with_enter);
-		va_end(ev.ap);
-	}
-
-	for (int i = 0; i < MAX_CALLBACKS && L.callbacks[i].fn; i++)
-	{
-		Callback *cb = &L.callbacks[i];
-		if (level >= cb->level)
-		{
-			init_event(&ev, cb->udata);
-			va_start(ev.ap, fmt);
-			cb->fn(&ev);
-			va_end(ev.ap);
-		}
-	}
-
-	unlock();
+    unlock();
 }
 
 pthread_mutex_t MUTEX_LOG;
 void log_lock(bool lock, void *udata);
 
-void multithread_log_init()
-{
-	pthread_mutex_init(&MUTEX_LOG, NULL);
-	log_set_lock(log_lock, &MUTEX_LOG);
+void multithread_log_init() {
+    pthread_mutex_init(&MUTEX_LOG, NULL);
+    log_set_lock(log_lock, &MUTEX_LOG);
 }
 
-void mutithread_log_exit()
-{
-	pthread_mutex_destroy(&MUTEX_LOG);
-}
+void mutithread_log_exit() { pthread_mutex_destroy(&MUTEX_LOG); }
 
-void log_lock(bool lock, void *udata)
-{
-	pthread_mutex_t *LOCK = (pthread_mutex_t *)(udata);
-	if (lock)
-		pthread_mutex_lock(LOCK);
-	else
-		pthread_mutex_unlock(LOCK);
+void log_lock(bool lock, void *udata) {
+    pthread_mutex_t *LOCK = (pthread_mutex_t *)(udata);
+    if (lock)
+        pthread_mutex_lock(LOCK);
+    else
+        pthread_mutex_unlock(LOCK);
 }

--- a/tools/virtio.c
+++ b/tools/virtio.c
@@ -1,26 +1,27 @@
+#include "virtio.h"
+#include "cJSON.h"
+#include "hvisor.h"
+#include "log.h"
+#include "virtio_blk.h"
+#include "virtio_console.h"
+#include "virtio_gpu.h"
+#include "virtio_net.h"
+#include <errno.h>
+#include <fcntl.h>
+#include <getopt.h>
+#include <limits.h>
+#include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include "virtio.h"
-#include "hvisor.h"
-#include "virtio_blk.h"
-#include "virtio_net.h"
-#include "virtio_console.h"
-#include "log.h"
-#include <sys/mman.h>
-#include <sys/uio.h>
-#include <fcntl.h>
-#include <unistd.h>
-#include <errno.h>
 #include <sys/ioctl.h>
-#include <getopt.h>
-#include <signal.h>
-#include <time.h>
-#include <sys/time.h>                                                                                           
-#include <limits.h>
-#include <sys/stat.h>
+#include <sys/mman.h>
 #include <sys/prctl.h>
-#include "cJSON.h"
+#include <sys/stat.h>
+#include <sys/time.h>
+#include <sys/uio.h>
+#include <time.h>
+#include <unistd.h>
 
 /// hvisor kernel module fd
 int ko_fd;
@@ -41,6 +42,23 @@ unsigned long long zone_mem[MAX_ZONES][MAX_RAMS][4];
 
 #define WAIT_TIME 1000 // 1ms
 
+const char *virtio_device_type_to_string(VirtioDeviceType type) {
+    switch (type) {
+    case VirtioTNone:
+        return "virtio-none";
+    case VirtioTNet:
+        return "virtio-net";
+    case VirtioTBlock:
+        return "virtio-blk";
+    case VirtioTConsole:
+        return "virtio-console";
+    case VirtioTGPU:
+        return "virtio-gpu";
+    default:
+        return "unknown";
+    }
+}
+
 int set_nonblocking(int fd) {
     int flags = fcntl(fd, F_GETFL, 0);
     if (flags == -1) {
@@ -54,20 +72,23 @@ int set_nonblocking(int fd) {
     return 0;
 }
 
-static int get_zone_ram_index(void* zonex_ipa, int zone_id) {
-    for(int i=0; i<MAX_RAMS; i++) {
-        if (zone_mem[zone_id][i][MEM_SIZE] == 0) 
-            continue;;
-        if (zonex_ipa >= zone_mem[zone_id][i][ZONEX_IPA] && zonex_ipa < zone_mem[zone_id][i][ZONEX_IPA] + zone_mem[zone_id][i][MEM_SIZE]) {
-           return i; 
+int get_zone_ram_index(void *zonex_ipa, int zone_id) {
+    for (int i = 0; i < MAX_RAMS; i++) {
+        if (zone_mem[zone_id][i][MEM_SIZE] == 0)
+            continue;
+        ;
+        if (zonex_ipa >= zone_mem[zone_id][i][ZONEX_IPA] &&
+            zonex_ipa < zone_mem[zone_id][i][ZONEX_IPA] +
+                            zone_mem[zone_id][i][MEM_SIZE]) {
+            return i;
         }
     }
     log_error("can't find zone mem index for zonex ipa %#x", zonex_ipa);
     return -1;
 }
 
-inline int is_queue_full(unsigned int front, unsigned int rear, unsigned int size)
-{
+inline int is_queue_full(unsigned int front, unsigned int rear,
+                         unsigned int size) {
     if (((rear + 1) & (size - 1)) == front) {
         return 1;
     } else {
@@ -75,143 +96,189 @@ inline int is_queue_full(unsigned int front, unsigned int rear, unsigned int siz
     }
 }
 
-inline int is_queue_empty(unsigned int front, unsigned int rear)
-{
+inline int is_queue_empty(unsigned int front, unsigned int rear) {
     return rear == front;
 }
 
-/// Write barrier to make sure all write operations are finished before this operation
-static inline void write_barrier(void) {
-    #ifdef ARM64
-        asm volatile ("dmb ishst":: : "memory");
-    #endif
-    #ifdef RISCV64
-        asm volatile ("fence w,w"::: "memory");
-    #endif
+/// Write barrier to make sure all write operations are finished before this
+/// operation
+inline void write_barrier(void) {
+#ifdef ARM64
+    asm volatile("dmb ishst" ::: "memory");
+#endif
+#ifdef RISCV64
+    asm volatile("fence w,w" ::: "memory");
+#endif
 }
 
-static inline void read_barrier(void) {
-    #ifdef ARM64
-        asm volatile ("dmb ishld":: : "memory");
-    #endif
-    #ifdef RISCV64
-        asm volatile ("fence r,r"::: "memory");
-    #endif
+inline void read_barrier(void) {
+#ifdef ARM64
+    asm volatile("dmb ishld" ::: "memory");
+#endif
+#ifdef RISCV64
+    asm volatile("fence r,r" ::: "memory");
+#endif
 }
 
-static inline void rw_barrier(void) {
-    #ifdef ARM64
-        asm volatile ("dmb ish":: : "memory");
-    #endif
-    #ifdef RISCV64
-        asm volatile ("fence rw,rw"::: "memory");
-    #endif
+inline void rw_barrier(void) {
+#ifdef ARM64
+    asm volatile("dmb ish" ::: "memory");
+#endif
+#ifdef RISCV64
+    asm volatile("fence rw,rw" ::: "memory");
+#endif
 }
 
 // create a virtio device.
-static VirtIODevice *create_virtio_device(VirtioDeviceType dev_type, uint32_t zone_id, 
-						uint64_t base_addr, uint64_t len, uint32_t irq_id, void* arg0, void *arg1)
-{
-	log_info("create virtio device type %d, zone id %d, base addr %lx, len %lx, irq id %d", 
-				dev_type, zone_id, base_addr, len, irq_id);
+VirtIODevice *create_virtio_device(VirtioDeviceType dev_type, uint32_t zone_id,
+                                   uint64_t base_addr, uint64_t len,
+                                   uint32_t irq_id, void *arg0, void *arg1) {
+    log_info(
+        "create virtio device type %s, zone id %d, base addr %lx, len %lx, "
+        "irq id %d",
+        virtio_device_type_to_string(dev_type), zone_id, base_addr, len,
+        irq_id);
     VirtIODevice *vdev = NULL;
     int is_err;
-	vdev = calloc(1, sizeof(VirtIODevice));
-	init_mmio_regs(&vdev->regs, dev_type);
-	vdev->base_addr = base_addr;
-	vdev->len = len;
-	vdev->zone_id = zone_id;
-	vdev->irq_id = irq_id;
-	vdev->type = dev_type;
-    switch (dev_type)
-    {
-    case VirtioTBlock: 
+    vdev = calloc(1, sizeof(VirtIODevice));
+    init_mmio_regs(&vdev->regs, dev_type);
+    vdev->base_addr = base_addr;
+    vdev->len = len;
+    vdev->zone_id = zone_id;
+    vdev->irq_id = irq_id;
+    vdev->type = dev_type;
+
+    // 根据设备类型进行初始化
+    switch (dev_type) {
+    case VirtioTBlock:
         vdev->regs.dev_feature = BLK_SUPPORTED_FEATURES;
         vdev->dev = init_blk_dev(vdev);
         init_virtio_queue(vdev, dev_type);
-        is_err = virtio_blk_init(vdev, (const char*)arg0);
+        is_err = virtio_blk_init(vdev, (const char *)arg0);
         break;
+
     case VirtioTNet:
         vdev->regs.dev_feature = NET_SUPPORTED_FEATURES;
         vdev->dev = init_net_dev(arg0);
         init_virtio_queue(vdev, dev_type);
         is_err = virtio_net_init(vdev, (char *)arg1);
         break;
+
     case VirtioTConsole:
         vdev->regs.dev_feature = CONSOLE_SUPPORTED_FEATURES;
         vdev->dev = init_console_dev();
         init_virtio_queue(vdev, dev_type);
         is_err = virtio_console_init(vdev);
         break;
-	default:
-		log_error("unsupported virtio device type\n");
-		goto err;
+
+    case VirtioTGPU:
+        vdev->regs.dev_feature = GPU_SUPPORTED_FEATURES;
+        vdev->dev = init_gpu_dev((GPURequestedState *)arg0);
+        free(arg0);
+        init_virtio_queue(vdev, dev_type);
+        is_err = virtio_gpu_init(vdev);
+        break;
+
+    default:
+        log_error("unsupported virtio device type\n");
+        goto err;
     }
-    if (is_err) goto err;
+
+    if (is_err)
+        goto err;
+
+    // If reaches max number of virtual devices
     if (vdevs_num == MAX_DEVS) {
         log_error("virtio device num exceed max limit");
         goto err;
     }
-    log_info("create virtio device %d success", dev_type);
+
+    if (vdev->dev == NULL) {
+        log_error("failed to init dev");
+        goto err;
+    }
+
+    log_info("create %s success", virtio_device_type_to_string(dev_type));
     vdevs[vdevs_num++] = vdev;
+
     return vdev;
 
 err:
-	free(vdev);
-	return NULL;
+    free(vdev);
+    return NULL;
 }
 
-void init_virtio_queue(VirtIODevice *vdev, VirtioDeviceType type)
-{
-    VirtQueue *vq = NULL;
-    switch (type)
-    {
+void init_virtio_queue(VirtIODevice *vdev, VirtioDeviceType type) {
+    VirtQueue *vqs = NULL;
+
+    log_info("Initializing virtio queue for zone:%d, device type:%s",
+             vdev->zone_id, virtio_device_type_to_string(type));
+
+    switch (type) {
     case VirtioTBlock:
         vdev->vqs_len = 1;
-        vq = malloc(sizeof(VirtQueue));
-        virtqueue_reset(vq, 0);
-        vq->queue_num_max = VIRTQUEUE_BLK_MAX_SIZE;
-        vq->notify_handler = virtio_blk_notify_handler;
-        vq->dev = vdev;
-        vdev->vqs = vq;
+        vqs = malloc(sizeof(VirtQueue));
+        virtqueue_reset(vqs, 0);
+        vqs->queue_num_max = VIRTQUEUE_BLK_MAX_SIZE;
+        vqs->notify_handler = virtio_blk_notify_handler;
+        vqs->dev = vdev;
+        vdev->vqs = vqs;
         break;
+
     case VirtioTNet:
         vdev->vqs_len = NET_MAX_QUEUES;
-        vq = malloc(sizeof(VirtQueue) * NET_MAX_QUEUES);
+        vqs = malloc(sizeof(VirtQueue) * NET_MAX_QUEUES);
         for (int i = 0; i < NET_MAX_QUEUES; ++i) {
-            virtqueue_reset(vq, i);
-            vq[i].queue_num_max = VIRTQUEUE_NET_MAX_SIZE;
-            vq[i].dev = vdev;
+            virtqueue_reset(vqs, i);
+            vqs[i].queue_num_max = VIRTQUEUE_NET_MAX_SIZE;
+            vqs[i].dev = vdev;
         }
-        vq[NET_QUEUE_RX].notify_handler = virtio_net_rxq_notify_handler;
-        vq[NET_QUEUE_TX].notify_handler = virtio_net_txq_notify_handler;
-        vdev->vqs = vq;
+        vqs[NET_QUEUE_RX].notify_handler = virtio_net_rxq_notify_handler;
+        vqs[NET_QUEUE_TX].notify_handler = virtio_net_txq_notify_handler;
+        vdev->vqs = vqs;
         break;
+
     case VirtioTConsole:
         vdev->vqs_len = CONSOLE_MAX_QUEUES;
-        vq = malloc(sizeof(VirtQueue) * CONSOLE_MAX_QUEUES);
+        vqs = malloc(sizeof(VirtQueue) * CONSOLE_MAX_QUEUES);
         for (int i = 0; i < CONSOLE_MAX_QUEUES; ++i) {
-            virtqueue_reset(vq, i);
-            vq[i].queue_num_max = VIRTQUEUE_CONSOLE_MAX_SIZE;
-            vq[i].dev = vdev;
+            virtqueue_reset(vqs, i);
+            vqs[i].queue_num_max = VIRTQUEUE_CONSOLE_MAX_SIZE;
+            vqs[i].dev = vdev;
         }
-        vq[CONSOLE_QUEUE_RX].notify_handler = virtio_console_rxq_notify_handler;
-        vq[CONSOLE_QUEUE_TX].notify_handler = virtio_console_txq_notify_handler;
-        vdev->vqs = vq;
+        vqs[CONSOLE_QUEUE_RX].notify_handler =
+            virtio_console_rxq_notify_handler;
+        vqs[CONSOLE_QUEUE_TX].notify_handler =
+            virtio_console_txq_notify_handler;
+        vdev->vqs = vqs;
         break;
+
+    case VirtioTGPU:
+        vdev->vqs_len = GPU_MAX_QUEUES;
+        vqs = malloc(sizeof(VirtQueue) * GPU_MAX_QUEUES);
+        for (int i = 0; i < GPU_MAX_QUEUES; ++i) {
+            virtqueue_reset(vqs, i);
+            vqs[i].queue_num_max = VIRTQUEUE_GPU_MAX_SIZE;
+            vqs[i].dev = vdev;
+        }
+        vqs[GPU_CONTROL_QUEUE].notify_handler = virtio_gpu_ctrl_notify_handler;
+        vqs[GPU_CURSOR_QUEUE].notify_handler = virtio_gpu_cursor_notify_handler;
+        vdev->vqs = vqs;
+        break;
+
     default:
         break;
     }
 }
 
-void init_mmio_regs(VirtMmioRegs *regs, VirtioDeviceType type)
-{
+void init_mmio_regs(VirtMmioRegs *regs, VirtioDeviceType type) {
+    log_info("initializing mmio registers for %s",
+             virtio_device_type_to_string(type));
     regs->device_id = type;
     regs->queue_sel = 0;
 }
 
-void virtio_dev_reset(VirtIODevice *vdev)
-{
+void virtio_dev_reset(VirtIODevice *vdev) {
     // When driver read first 4 encoded messages, it will reset dev.
     log_trace("virtio dev reset");
     vdev->regs.status = 0;
@@ -219,105 +286,105 @@ void virtio_dev_reset(VirtIODevice *vdev)
     vdev->regs.interrupt_count = 0;
     int idx = vdev->regs.queue_sel;
     vdev->vqs[idx].ready = 0;
-    for(uint32_t i=0; i<vdev->vqs_len; i++) {
+    for (uint32_t i = 0; i < vdev->vqs_len; i++) {
         virtqueue_reset(&vdev->vqs[i], i);
     }
     vdev->activated = false;
 }
 
-void virtqueue_reset(VirtQueue *vq, int idx)
-{
-    // reserve these fields
+void virtqueue_reset(VirtQueue *vq, int idx) {
+    // Reserve these fields
     void *addr = vq->notify_handler;
     VirtIODevice *dev = vq->dev;
     uint32_t queue_num_max = vq->queue_num_max;
+
+    // Clear others
     memset(vq, 0, sizeof(VirtQueue));
     vq->vq_idx = idx;
     vq->notify_handler = addr;
     vq->dev = dev;
     vq->queue_num_max = queue_num_max;
-	pthread_mutex_init(&vq->used_ring_lock, NULL);
+    pthread_mutex_init(&vq->used_ring_lock, NULL);
 }
 
 // check if virtqueue has new requests
-bool virtqueue_is_empty(VirtQueue *vq)
-{
-    if(vq->avail_ring == NULL) {
+bool virtqueue_is_empty(VirtQueue *vq) {
+    if (vq->avail_ring == NULL) {
         log_error("virtqueue's avail ring is invalid");
         return true;
     }
-	// read_barrier();
-	log_debug("vq->last_avail_idx is %d, vq->avail_ring->idx is %d", vq->last_avail_idx, vq->avail_ring->idx);
+    // read_barrier();
+    log_debug("vq->last_avail_idx is %d, vq->avail_ring->idx is %d",
+              vq->last_avail_idx, vq->avail_ring->idx);
     if (vq->last_avail_idx == vq->avail_ring->idx)
         return true;
     else
         return false;
 }
 
-bool desc_is_writable(volatile VirtqDesc *desc_table, uint16_t idx)
-{
+bool desc_is_writable(volatile VirtqDesc *desc_table, uint16_t idx) {
     if (desc_table[idx].flags & VRING_DESC_F_WRITE)
         return true;
     return false;
 }
 
-
-static void* get_virt_addr(void *zonex_ipa, int zone_id)
-{
+void *get_virt_addr(void *zonex_ipa, int zone_id) {
     int ram_idx = get_zone_ram_index(zonex_ipa, zone_id);
-    return zone_mem[zone_id][ram_idx][VIRT_ADDR] - zone_mem[zone_id][ram_idx][ZONEX_IPA] + zonex_ipa;
+    return zone_mem[zone_id][ram_idx][VIRT_ADDR] -
+           zone_mem[zone_id][ram_idx][ZONEX_IPA] + zonex_ipa;
 }
 
-// When virtio device is processing virtqueue, driver adding an elem to virtqueue is no need to notify device.
+// When virtio device is processing virtqueue, driver adding an elem to
+// virtqueue is no need to notify device.
 void virtqueue_disable_notify(VirtQueue *vq) {
-	if (vq->event_idx_enabled) {
-		VQ_AVAIL_EVENT(vq) = vq->last_avail_idx - 1;
-	} else {
-    	vq->used_ring->flags |= (uint16_t)VRING_USED_F_NO_NOTIFY;
-	}
-	write_barrier();
+    if (vq->event_idx_enabled) {
+        VQ_AVAIL_EVENT(vq) = vq->last_avail_idx - 1;
+    } else {
+        vq->used_ring->flags |= (uint16_t)VRING_USED_F_NO_NOTIFY;
+    }
+    write_barrier();
 }
 
 void virtqueue_enable_notify(VirtQueue *vq) {
-	if (vq->event_idx_enabled) {
-		VQ_AVAIL_EVENT(vq) = vq->avail_ring->idx;
-	} else {
-   		vq->used_ring->flags &= !(uint16_t)VRING_USED_F_NO_NOTIFY;
-	} 
-	write_barrier();
+    if (vq->event_idx_enabled) {
+        VQ_AVAIL_EVENT(vq) = vq->avail_ring->idx;
+    } else {
+        vq->used_ring->flags &= !(uint16_t)VRING_USED_F_NO_NOTIFY;
+    }
+    write_barrier();
 }
 
-void virtqueue_set_desc_table(VirtQueue *vq)
-{
+void virtqueue_set_desc_table(VirtQueue *vq) {
     int zone_id = vq->dev->zone_id;
-    log_trace("desc table ipa is %#x", vq->desc_table_addr);
+    log_debug("zone %d set dev %s desc table ipa at %#x", zone_id,
+              virtio_device_type_to_string(vq->dev->type), vq->desc_table_addr);
     vq->desc_table = (VirtqDesc *)get_virt_addr(vq->desc_table_addr, zone_id);
-
 }
 
-void virtqueue_set_avail(VirtQueue *vq)
-{
+void virtqueue_set_avail(VirtQueue *vq) {
     int zone_id = vq->dev->zone_id;
-    log_trace("avail ring ipa is %#x", vq->avail_addr);
+    log_debug("zone %d set dev %s avail ring ipa at %#x", zone_id,
+              virtio_device_type_to_string(vq->dev->type), vq->avail_addr);
     vq->avail_ring = (VirtqAvail *)get_virt_addr(vq->avail_addr, zone_id);
 }
 
-void virtqueue_set_used(VirtQueue *vq)
-{
+void virtqueue_set_used(VirtQueue *vq) {
     int zone_id = vq->dev->zone_id;
-    log_trace("used ring ipa is %#x", vq->used_addr);
+    log_debug("zone %d set dev %s used ring ipa at %#x", zone_id,
+              virtio_device_type_to_string(vq->dev->type), vq->used_addr);
     vq->used_ring = (VirtqUsed *)get_virt_addr(vq->used_addr, zone_id);
 }
 
 // record one descriptor to iov.
-static inline int descriptor2iov(int i, volatile VirtqDesc *vd,
-           struct iovec *iov, uint16_t *flags, int zone_id) {
+inline int descriptor2iov(int i, volatile VirtqDesc *vd, struct iovec *iov,
+                          uint16_t *flags, int zone_id, bool copy_flags) {
     void *host_addr;
     host_addr = get_virt_addr((void *)vd->addr, zone_id);
     iov[i].iov_base = host_addr;
     iov[i].iov_len = vd->len;
-    // log_debug("vd->addr ipa is %x, iov_base is %x, iov_len is %d", vd->addr, host_addr, vd->len);
-    if (flags != NULL)
+    // log_debug("vd->addr ipa is %x, iov_base is %x, iov_len is %d", vd->addr,
+    // host_addr, vd->len);
+    if (copy_flags)
         flags[i] = vd->flags;
     return 0;
 }
@@ -329,70 +396,100 @@ static inline int descriptor2iov(int i, volatile VirtqDesc *vd,
 /// \param append_len the number of iovs to append
 /// \return the len of iovs
 int process_descriptor_chain(VirtQueue *vq, uint16_t *desc_idx,
-                struct iovec **iov, uint16_t **flags, int append_len)
-{
-    uint16_t next, idx;
+                             struct iovec **iov, uint16_t **flags,
+                             int append_len, bool copy_flags) {
+    uint16_t next, last_avail_idx;
     volatile VirtqDesc *vdesc, *ind_table, *ind_desc;
-	int chain_len = 0, i, table_len;
-    idx = vq->last_avail_idx;
-    if(idx == vq->avail_ring->idx)
+    int chain_len = 0, i, table_len;
+
+    // idx is the last available index processed during the last kick
+    last_avail_idx = vq->last_avail_idx;
+
+    // No new requests
+    if (last_avail_idx == vq->avail_ring->idx)
         return 0;
+
+    // Update to the index to be processed during this kick
     vq->last_avail_idx++;
-    *desc_idx = next = vq->avail_ring->ring[idx & (vq->num - 1)];
-	// record desc chain' len to chain_len
-	for (i=0; i<(int)vq->num; i++, next = vdesc->next) {
+
+    // Get the index of the first available descriptor
+    *desc_idx = next = vq->avail_ring->ring[last_avail_idx & (vq->num - 1)];
+    // Record the length of the descriptor chain to chain_len
+    for (i = 0; i < (int)vq->num; i++, next = vdesc->next) {
+        // Get a descriptor
         vdesc = &vq->desc_table[next];
-		// TODO: vdesc->len may be not chain_len, virtio specification doesn't say it.
-		if (vdesc->flags & VRING_DESC_F_INDIRECT) {
-			chain_len += vdesc->len / 16;
-			i--;
-		}
-		if ((vdesc->flags & VRING_DESC_F_NEXT) == 0)
+        // TODO: vdesc->len may not be chain_len, virtio specification doesn't
+        // say it.
+
+        // Check if this descriptor supports the VRING_DESC_F_INDIRECT feature
+        // If supported, it means that the descriptor points to a set of
+        // descriptors, i.e., one descriptor can describe multiple scattered
+        // buffers
+        if (vdesc->flags & VRING_DESC_F_INDIRECT) {
+            chain_len +=
+                vdesc->len / 16; // This descriptor points to 16 descriptors
+            i--;
+        }
+        // Exit if there is no next descriptor
+        if ((vdesc->flags & VRING_DESC_F_NEXT) == 0)
             break;
-	}
+    }
 
-	chain_len += i + 1, next = *desc_idx;
-	
-	*iov = malloc(sizeof(struct iovec) * ( chain_len + append_len));
-	if (flags != NULL)
-		*flags = malloc(sizeof(uint16_t) * ( chain_len + append_len));
+    // Update chain length and reset next to the first descriptor
+    chain_len += i + 1, next = *desc_idx;
 
-	for (i=0; i<chain_len; i++, next = vdesc->next) {
-		vdesc = &vq->desc_table[next];
-		if (vdesc->flags & VRING_DESC_F_INDIRECT) {
-			ind_table = (VirtqDesc *)(get_virt_addr((void *)vdesc->addr, vq->dev->zone_id));
-			table_len = vdesc->len / 16;
-			log_debug("table_len is %d", table_len);
-			next = 0;
-			for (;;) {
-				log_debug("next is %d", next);
-				ind_desc = &ind_table[next];
-				descriptor2iov(i, ind_desc, *iov, flags == NULL ? NULL : *flags, vq->dev->zone_id);
-				table_len--;
-				i++;
-				if ((ind_desc->flags & VRING_DESC_F_NEXT) == 0)
-            		break;
-				next = ind_desc->next;
-			}
-			if (table_len != 0) {
-				log_error("invalid indirect descriptor chain");
-				break;
-			}
-		} else {
-			descriptor2iov(i, vdesc, *iov, flags == NULL ? NULL : *flags, vq->dev->zone_id);
-		}
-	}
+    // Allocate a buffer for each descriptor, using iov to manage them uniformly
+    *iov = malloc(sizeof(struct iovec) * (chain_len + append_len));
+    if (copy_flags)
+        // Record the flag of each descriptor
+        *flags = malloc(sizeof(uint16_t) * (chain_len + append_len));
+
+    // Traverse the descriptor chain and copy the buffer pointed to by each
+    // descriptor to iov
+    for (i = 0; i < chain_len; i++, next = vdesc->next) {
+        vdesc = &vq->desc_table[next];
+        // If the descriptor supports the VRING_DESC_F_INDIRECT feature
+        if (vdesc->flags & VRING_DESC_F_INDIRECT) {
+            // Get the address of the indirect table pointed to by this
+            // descriptor
+            ind_table = (VirtqDesc *)(get_virt_addr((void *)vdesc->addr,
+                                                    vq->dev->zone_id));
+            table_len = vdesc->len / 16;
+            log_debug("find indirect desc, table_len is %d", table_len);
+            next = 0;
+            for (;;) {
+                // log_debug("indirect desc next is %d", next);
+                ind_desc = &ind_table[next];
+                descriptor2iov(i, ind_desc, *iov, *flags, vq->dev->zone_id,
+                               copy_flags);
+                table_len--;
+                i++;
+                // No more next descriptor
+                if ((ind_desc->flags & VRING_DESC_F_NEXT) == 0)
+                    break;
+                next = ind_desc->next;
+            }
+            if (table_len != 0) {
+                log_error("invalid indirect descriptor chain");
+                break;
+            }
+        } else {
+            // For a normal descriptor, copy it directly to iov
+            descriptor2iov(i, vdesc, *iov, *flags, vq->dev->zone_id,
+                           copy_flags);
+        }
+    }
     return chain_len;
 }
 
-void update_used_ring(VirtQueue *vq, uint16_t idx, uint32_t iolen)
-{
+void update_used_ring(VirtQueue *vq, uint16_t idx, uint32_t iolen) {
     volatile VirtqUsed *used_ring;
     volatile VirtqUsedElem *elem;
     uint16_t used_idx, mask;
-	// There is no need to worry about if used_ring is full, because used_ring's len is equal to descriptor table's. 
+    // There is no need to worry about if used_ring is full, because used_ring's
+    // len is equal to descriptor table's.
     write_barrier();
-	// pthread_mutex_lock(&vq->used_ring_lock);
+    // pthread_mutex_lock(&vq->used_ring_lock);
     used_ring = vq->used_ring;
     used_idx = used_ring->idx;
     mask = vq->num - 1;
@@ -400,30 +497,36 @@ void update_used_ring(VirtQueue *vq, uint16_t idx, uint32_t iolen)
     elem->id = idx;
     elem->len = iolen;
     used_ring->idx = used_idx;
-	write_barrier();
-	// pthread_mutex_unlock(&vq->used_ring_lock);
-    log_debug("update used ring: used_idx is %d, elem->idx is %d, vq->num is %d", used_idx, idx, vq->num);
+    write_barrier();
+    // pthread_mutex_unlock(&vq->used_ring_lock);
+    log_debug(
+        "update used ring: used_idx is %d, elem->idx is %d, vq->num is %d",
+        used_idx, idx, vq->num);
 }
 
-static uint64_t virtio_mmio_read(VirtIODevice *vdev, uint64_t offset, unsigned size)
-{
+uint64_t virtio_mmio_read(VirtIODevice *vdev, uint64_t offset, unsigned size) {
     log_debug("virtio mmio read at %#x", offset);
+
     if (!vdev) {
         switch (offset) {
         case VIRTIO_MMIO_MAGIC_VALUE:
+            log_debug("read VIRTIO_MMIO_MAGIC_VALUE");
             return VIRT_MAGIC;
         case VIRTIO_MMIO_VERSION:
+            log_debug("read VIRTIO_MMIO_VERSION");
             return VIRT_VERSION;
         case VIRTIO_MMIO_VENDOR_ID:
+            log_debug("read VIRTIO_MMIO_VENDOR_ID");
             return VIRT_VENDOR;
         default:
             return 0;
         }
-    } 
-    
+    }
+
     if (offset >= VIRTIO_MMIO_CONFIG) {
         offset -= VIRTIO_MMIO_CONFIG;
         // the first member of vdev->dev must be config.
+        log_debug("read virtio dev config");
         return *(uint64_t *)(vdev->dev + offset);
     }
 
@@ -434,31 +537,43 @@ static uint64_t virtio_mmio_read(VirtIODevice *vdev, uint64_t offset, unsigned s
 
     switch (offset) {
     case VIRTIO_MMIO_MAGIC_VALUE:
+        log_debug("read VIRTIO_MMIO_MAGIC_VALUE");
         return VIRT_MAGIC;
     case VIRTIO_MMIO_VERSION:
+        log_debug("read VIRTIO_MMIO_VERSION");
         return VIRT_VERSION;
     case VIRTIO_MMIO_DEVICE_ID:
+        log_debug("read VIRTIO_MMIO_DEVICE_ID");
         return vdev->regs.device_id;
     case VIRTIO_MMIO_VENDOR_ID:
+        log_debug("read VIRTIO_MMIO_VENDOR_ID");
         return VIRT_VENDOR;
     case VIRTIO_MMIO_DEVICE_FEATURES:
+        log_debug("read VIRTIO_MMIO_DEVICE_FEATURES");
+
         if (vdev->regs.dev_feature_sel) {
             return vdev->regs.dev_feature >> 32;
         } else {
             return vdev->regs.dev_feature;
         }
     case VIRTIO_MMIO_QUEUE_NUM_MAX:
+        log_debug("read VIRTIO_MMIO_QUEUE_NUM_MAX");
         return vdev->vqs[vdev->regs.queue_sel].queue_num_max;
     case VIRTIO_MMIO_QUEUE_READY:
+        log_debug("read VIRTIO_MMIO_QUEUE_READY");
         return vdev->vqs[vdev->regs.queue_sel].ready;
     case VIRTIO_MMIO_INTERRUPT_STATUS:
-		if (vdev->regs.interrupt_status == 0) {
-			log_error("virtio-mmio-read: interrupt status is 0, type is %d", vdev->type);
-		}
+        log_debug("read VIRTIO_MMIO_INTERRUPT_STATUS");
+        if (vdev->regs.interrupt_status == 0) {
+            log_error("virtio-mmio-read: interrupt status is 0, type is %d",
+                      vdev->type);
+        }
         return vdev->regs.interrupt_status;
     case VIRTIO_MMIO_STATUS:
+        log_debug("read VIRTIO_MMIO_STATUS");
         return vdev->regs.status;
     case VIRTIO_MMIO_CONFIG_GENERATION:
+        log_debug("read VIRTIO_MMIO_CONFIG_GENERATION");
         return vdev->regs.generation;
     case VIRTIO_MMIO_DEVICE_FEATURES_SEL:
     case VIRTIO_MMIO_DRIVER_FEATURES:
@@ -482,8 +597,8 @@ static uint64_t virtio_mmio_read(VirtIODevice *vdev, uint64_t offset, unsigned s
     return 0;
 }
 
-static void virtio_mmio_write(VirtIODevice *vdev, uint64_t offset, uint64_t value, unsigned size)
-{
+void virtio_mmio_write(VirtIODevice *vdev, uint64_t offset, uint64_t value,
+                       unsigned size) {
     log_debug("virtio mmio write at %#x, value is %#x\n", offset, value);
     VirtMmioRegs *regs = &vdev->regs;
     VirtQueue *vqs = vdev->vqs;
@@ -503,6 +618,7 @@ static void virtio_mmio_write(VirtIODevice *vdev, uint64_t offset, uint64_t valu
 
     switch (offset) {
     case VIRTIO_MMIO_DEVICE_FEATURES_SEL:
+        log_debug("write VIRTIO_MMIO_DEVICE_FEATURES_SEL");
         if (value) {
             regs->dev_feature_sel = 1;
         } else {
@@ -510,18 +626,28 @@ static void virtio_mmio_write(VirtIODevice *vdev, uint64_t offset, uint64_t valu
         }
         break;
     case VIRTIO_MMIO_DRIVER_FEATURES:
+        log_debug("zone %d driver set device %s, accepted features %d",
+                  vdev->zone_id, virtio_device_type_to_string(vdev->type),
+                  value);
         if (regs->drv_feature_sel) {
             regs->drv_feature |= value << 32;
         } else {
             regs->drv_feature |= value;
         }
-		if (regs->drv_feature & (1ULL << VIRTIO_RING_F_EVENT_IDX)) {
-			int len = vdev->vqs_len;
-			for (int i=0; i<len; i++) 
-				vqs[i].event_idx_enabled = 1;
-		}
+
+        // If the driver frontend has activated VIRTIO_RING_F_EVENT_IDX, enable
+        // the related settings
+        if (regs->drv_feature & (1ULL << VIRTIO_RING_F_EVENT_IDX)) {
+            log_debug("zone %d driver accepted VIRTIO_RING_F_EVENT_IDX",
+                      vdev->zone_id);
+            int len = vdev->vqs_len;
+            for (int i = 0; i < len; i++)
+                vqs[i].event_idx_enabled = 1;
+        }
         break;
     case VIRTIO_MMIO_DRIVER_FEATURES_SEL:
+        log_debug("write VIRTIO_MMIO_DRIVER_FEATURES_SEL");
+
         if (value) {
             regs->drv_feature_sel = 1;
         } else {
@@ -529,58 +655,90 @@ static void virtio_mmio_write(VirtIODevice *vdev, uint64_t offset, uint64_t valu
         }
         break;
     case VIRTIO_MMIO_QUEUE_SEL:
+        log_debug("zone %d driver set device %s, selecting queue %d",
+                  vdev->zone_id, virtio_device_type_to_string(vdev->type),
+                  value);
+
         if (value < vdev->vqs_len) {
             regs->queue_sel = value;
         }
         break;
     case VIRTIO_MMIO_QUEUE_NUM:
+        log_debug("zone %d driver set device %s, use virtqueue num %d",
+                  vdev->zone_id, virtio_device_type_to_string(vdev->type),
+                  value);
+
         vqs[regs->queue_sel].num = value;
-        log_trace("virtqueue num is %d", value);
         break;
     case VIRTIO_MMIO_QUEUE_READY:
+        log_debug("write VIRTIO_MMIO_QUEUE_READY");
+
         vqs[regs->queue_sel].ready = value;
         break;
     case VIRTIO_MMIO_QUEUE_NOTIFY:
-        log_debug("queue notify begin");
+        log_debug("****** zone %d %s queue notify begin ******", vdev->zone_id,
+                  virtio_device_type_to_string(vdev->type));
+
         if (value < vdev->vqs_len) {
-            log_trace("queue notify ready, handler addr is %#x", vqs[value].notify_handler);
+            log_trace("queue notify ready, handler addr is %#x",
+                      vqs[value].notify_handler);
             vqs[value].notify_handler(vdev, &vqs[value]);
         }
-        log_debug("queue notify end");
+
+        log_debug("****** zone %d %s queue notify end ******", vdev->zone_id,
+                  virtio_device_type_to_string(vdev->type));
+
         break;
     case VIRTIO_MMIO_INTERRUPT_ACK:
+        log_debug("write VIRTIO_MMIO_INTERRUPT_ACK");
+
         if (value == regs->interrupt_status && regs->interrupt_count > 0) {
-            regs->interrupt_count --;
+            regs->interrupt_count--;
             break;
         } else if (value != regs->interrupt_status) {
-            log_error("interrupt_status is not equal to ack, type is %d", vdev->type);
+            log_error("interrupt_status is not equal to ack, type is %d",
+                      vdev->type);
         }
         regs->interrupt_status &= !value;
         break;
     case VIRTIO_MMIO_STATUS:
+        log_debug("write VIRTIO_MMIO_STATUS");
+
         regs->status = value;
         if (regs->status == 0) {
             virtio_dev_reset(vdev);
         }
         break;
     case VIRTIO_MMIO_QUEUE_DESC_LOW:
+        log_debug("write VIRTIO_MMIO_QUEUE_DESC_LOW");
+
         vqs[regs->queue_sel].desc_table_addr |= value & UINT32_MAX;
         break;
     case VIRTIO_MMIO_QUEUE_DESC_HIGH:
+        log_debug("write VIRTIO_MMIO_QUEUE_DESC_HIGH");
+
         vqs[regs->queue_sel].desc_table_addr |= value << 32;
         virtqueue_set_desc_table(&vqs[regs->queue_sel]);
         break;
     case VIRTIO_MMIO_QUEUE_AVAIL_LOW:
+        log_debug("write VIRTIO_MMIO_QUEUE_AVAIL_LOW");
+
         vqs[regs->queue_sel].avail_addr |= value & UINT32_MAX;
         break;
     case VIRTIO_MMIO_QUEUE_AVAIL_HIGH:
+        log_debug("write VIRTIO_MMIO_QUEUE_AVAIL_HIGH");
+
         vqs[regs->queue_sel].avail_addr |= value << 32;
         virtqueue_set_avail(&vqs[regs->queue_sel]);
         break;
     case VIRTIO_MMIO_QUEUE_USED_LOW:
+        log_debug("write VIRTIO_MMIO_QUEUE_USED_LOW");
+
         vqs[regs->queue_sel].used_addr |= value & UINT32_MAX;
         break;
     case VIRTIO_MMIO_QUEUE_USED_HIGH:
+        log_debug("write VIRTIO_MMIO_QUEUE_USED_HIGH");
+
         vqs[regs->queue_sel].used_addr |= value << 32;
         virtqueue_set_used(&vqs[regs->queue_sel]);
         break;
@@ -600,35 +758,38 @@ static void virtio_mmio_write(VirtIODevice *vdev, uint64_t offset, uint64_t valu
     }
 }
 
-static inline bool in_range(uint64_t value, uint64_t lower, uint64_t len)
-{
+inline bool in_range(uint64_t value, uint64_t lower, uint64_t len) {
     return ((value >= lower) && (value < (lower + len)));
 }
 
-// Inject irq_id to target zone. It will add to res list, and notify hypervisor through ioctl.
-void virtio_inject_irq(VirtQueue *vq)
-{
-	uint16_t last_used_idx, idx, event_idx;
-	last_used_idx = vq->last_used_idx;
-	vq->last_used_idx = idx = vq->used_ring->idx;
-	// read_barrier();
-	if (idx == last_used_idx) {
-		log_debug("idx equals last_used_idx");
-		return ;
-	}
-    if (!vq->event_idx_enabled && (vq->avail_ring->flags & VRING_AVAIL_F_NO_INTERRUPT)) {
-		log_debug("no interrupt");
-		return ;
-	}
-	if (vq->event_idx_enabled) {
-		event_idx = VQ_USED_EVENT(vq);
-		log_debug("idx is %d, event_idx is %d, last_used_idx is %d", idx, event_idx, last_used_idx);
-		if(!vring_need_event(event_idx, idx, last_used_idx)) {
-			return;
-		}
-	}
+// Inject irq_id to target zone. It will add to res list, and notify hypervisor
+// through ioctl.
+void virtio_inject_irq(VirtQueue *vq) {
+    uint16_t last_used_idx, idx, event_idx;
+    last_used_idx = vq->last_used_idx;
+    vq->last_used_idx = idx = vq->used_ring->idx;
+    // read_barrier();
+    if (idx == last_used_idx) {
+        log_debug("idx equals last_used_idx");
+        return;
+    }
+    if (!vq->event_idx_enabled &&
+        (vq->avail_ring->flags & VRING_AVAIL_F_NO_INTERRUPT)) {
+        log_debug("no interrupt");
+        return;
+    }
+    if (vq->event_idx_enabled) {
+        event_idx = VQ_USED_EVENT(vq);
+        log_debug("idx is %d, event_idx is %d, last_used_idx is %d", idx,
+                  event_idx, last_used_idx);
+        if (!vring_need_event(event_idx, idx, last_used_idx)) {
+            return;
+        }
+    }
     volatile struct device_res *res;
-    while (is_queue_full(virtio_bridge->res_front, virtio_bridge->res_rear, MAX_REQ));
+    while (is_queue_full(virtio_bridge->res_front, virtio_bridge->res_rear,
+                         MAX_REQ))
+        ;
     pthread_mutex_lock(&RES_MUTEX);
     unsigned int res_rear = virtio_bridge->res_rear;
     res = &virtio_bridge->res_list[res_rear];
@@ -637,151 +798,172 @@ void virtio_inject_irq(VirtQueue *vq)
     write_barrier();
     virtio_bridge->res_rear = (res_rear + 1) & (MAX_REQ - 1);
     write_barrier();
-	vq->dev->regs.interrupt_status = VIRTIO_MMIO_INT_VRING;
-    vq->dev->regs.interrupt_count ++;
+    vq->dev->regs.interrupt_status = VIRTIO_MMIO_INT_VRING;
+    vq->dev->regs.interrupt_count++;
     pthread_mutex_unlock(&RES_MUTEX);
-	log_debug("inject irq to device %d, vq is %d", vq->dev->type, vq->vq_idx);
+    log_debug("inject irq to device %s, vq is %d",
+              virtio_device_type_to_string(vq->dev->type), vq->vq_idx);
     ioctl(ko_fd, HVISOR_FINISH_REQ);
 }
 
-static void virtio_finish_cfg_req(uint32_t target_cpu, uint64_t value) {
+void virtio_finish_cfg_req(uint32_t target_cpu, uint64_t value) {
     virtio_bridge->cfg_values[target_cpu] = value;
     write_barrier();
     virtio_bridge->cfg_flags[target_cpu]++;
     write_barrier();
 }
 
-static int virtio_handle_req(volatile struct device_req *req)
-{
+int virtio_handle_req(volatile struct device_req *req) {
     int i;
     uint64_t value = 0;
+
+    // Check if the request corresponds to a virtio device in a specific zone
     for (i = 0; i < vdevs_num; ++i) {
-        if ((req->src_zone == vdevs[i]->zone_id) && in_range(req->address, vdevs[i]->base_addr, vdevs[i]->len))
+        if ((req->src_zone == vdevs[i]->zone_id) &&
+            in_range(req->address, vdevs[i]->base_addr,
+                     vdevs[i]->len)) // Check if memory regions overlap
             break;
     }
+
     if (i == vdevs_num) {
-        log_error("no matched virtio dev in zone %d, address is 0x%x", req->src_zone, req->address);
+        log_warn("no matched virtio dev in zone %d, address is 0x%x",
+                 req->src_zone, req->address);
         value = virtio_mmio_read(NULL, 0, 0);
         virtio_finish_cfg_req(req->src_cpu, value);
         return -1;
     }
+
     VirtIODevice *vdev = vdevs[i];
-    if (vdev->type == VirtioTNet)
-        log_debug("vdev type is net");
-    else if (vdev->type == VirtioTBlock)
-        log_debug("vdev type is blk");
-    else if (vdev->type == VirtioTConsole)
-        log_debug("vdev type is con");
+
+    // if (vdev->type == VirtioTNet) {
+    //   log_info("handling request to net from zone %d", vdev->zone_id);
+    // } else if (vdev->type == VirtioTBlock) {
+    //   log_info("handling request to blk from zone %d", vdev->zone_id);
+    // } else if (vdev->type == VirtioTConsole) {
+    //   log_info("handling request to console from zone %d", vdev->zone_id);
+    // } else if (vdev->type == VirtioTGPU) {
+    //   log_info("handling request to gpu from zone %d", vdev->zone_id);
+    // }
+
     uint64_t offs = req->address - vdev->base_addr;
+
+    // Write or read the device's MMIO register
     if (req->is_write) {
         virtio_mmio_write(vdev, offs, req->value, req->size);
     } else {
         value = virtio_mmio_read(vdev, offs, req->size);
         log_debug("read value is 0x%x\n", value);
     }
+
+    // Control instructions do not require interrupts to return data
+    // The requester will block and wait
     if (!req->need_interrupt) {
         // If a request is a control not a data request
         virtio_finish_cfg_req(req->src_cpu, value);
-    } 
+    }
+
     log_trace("src_zone is %d, src_cpu is %lld", req->src_zone, req->src_cpu);
     return 0;
 }
 
-static void virtio_close() {
-	log_warn("virtio devices will be closed");
-	destroy_event_monitor();
-	for(int i=0; i<vdevs_num; i++)
+void virtio_close() {
+    log_warn("virtio devices will be closed");
+    destroy_event_monitor();
+    for (int i = 0; i < vdevs_num; i++)
         vdevs[i]->virtio_close(vdevs[i]);
-	close(ko_fd);
-	munmap((void *)virtio_bridge, MMAP_SIZE);
-    for(int i=0; i<MAX_ZONES; i++) {
-        for(int j=0; j< MAX_RAMS; j++)
+    close(ko_fd);
+    munmap((void *)virtio_bridge, MMAP_SIZE);
+    for (int i = 0; i < MAX_ZONES; i++) {
+        for (int j = 0; j < MAX_RAMS; j++)
             if (zone_mem[i][j][MEM_SIZE] != 0) {
-                munmap((void *)zone_mem[i][j][VIRT_ADDR], zone_mem[i][j][MEM_SIZE]);
+                munmap((void *)zone_mem[i][j][VIRT_ADDR],
+                       zone_mem[i][j][MEM_SIZE]);
             }
     }
-	mutithread_log_exit();
-	log_warn("virtio daemon exit successfully");
+    mutithread_log_exit();
+    log_warn("virtio daemon exit successfully");
 }
 
-void handle_virtio_requests()
-{
-	int sig;
-	sigset_t wait_set;
-	struct timespec timeout;
+void handle_virtio_requests() {
+    int sig;
+    sigset_t wait_set;
+    struct timespec timeout;
     unsigned int req_front = virtio_bridge->req_front;
     volatile struct device_req *req;
-	timeout.tv_sec = 0;
-	timeout.tv_nsec = WAIT_TIME;
-	sigemptyset(&wait_set);
-	sigaddset(&wait_set, SIGHVI);
-	sigaddset(&wait_set, SIGTERM);
-	virtio_bridge->need_wakeup = 1;
-	
-	int signal_count = 0, proc_count = 0;
-	unsigned long long count = 0;
-	for (;;) {
-		log_warn("signal_count is %d, proc_count is %d", signal_count, proc_count);
-		sigwait(&wait_set, &sig);
-		signal_count++;
-		if (sig == SIGTERM) {
-			virtio_close();
-			break;
-		} else if (sig != SIGHVI) {
-			log_error("unknown signal %d", sig);
-			continue;
-		}
-		while(1) {
-			if (!is_queue_empty(req_front, virtio_bridge->req_rear)) {
-				count = 0;
-				proc_count++;
-				req = &virtio_bridge->req_list[req_front];
-				virtio_bridge->need_wakeup = 0;
-				virtio_handle_req(req);
-				req_front = (req_front + 1) & (MAX_REQ - 1);
-				virtio_bridge->req_front = req_front;
-				write_barrier();
-			} 
-			else {
-				count++;
-				if (count < 10000000) 
-					continue;
-				count = 0;
-				virtio_bridge->need_wakeup = 1;
-				write_barrier();
-				nanosleep(&timeout, NULL);
-				if(is_queue_empty(req_front, virtio_bridge->req_rear)) {
-					break;
-				} 		
-			}
-		}
-	}
+    timeout.tv_sec = 0;
+    timeout.tv_nsec = WAIT_TIME;
+    sigemptyset(&wait_set);
+    sigaddset(&wait_set, SIGHVI);
+    sigaddset(&wait_set, SIGTERM);
+    virtio_bridge->need_wakeup = 1;
+
+    int signal_count = 0, proc_count = 0;
+    unsigned long long count = 0;
+    for (;;) {
+        log_warn("signal_count is %d, proc_count is %d", signal_count,
+                 proc_count);
+        sigwait(&wait_set, &sig);
+        signal_count++;
+        if (sig == SIGTERM) {
+            virtio_close();
+            break;
+        } else if (sig != SIGHVI) {
+            log_error("unknown signal %d", sig);
+            continue;
+        }
+        while (1) {
+            if (!is_queue_empty(req_front, virtio_bridge->req_rear)) {
+                count = 0;
+                proc_count++;
+                req = &virtio_bridge->req_list[req_front];
+                virtio_bridge->need_wakeup = 0;
+                virtio_handle_req(req);
+                req_front = (req_front + 1) & (MAX_REQ - 1);
+                virtio_bridge->req_front = req_front;
+                write_barrier();
+            } else {
+                count++;
+                if (count < 10000000)
+                    continue;
+                count = 0;
+                virtio_bridge->need_wakeup = 1;
+                write_barrier();
+                nanosleep(&timeout, NULL);
+                if (is_queue_empty(req_front, virtio_bridge->req_rear)) {
+                    break;
+                }
+            }
+        }
+    }
 }
 
 void initialize_log() {
     int log_level;
-    #ifdef HLOG
-        log_level = HLOG;
-    #else 
-        log_level = LOG_WARN;
-    #endif
+#ifdef HLOG
+    log_level = HLOG;
+#else
+    log_level = LOG_WARN;
+#endif
     log_set_level(log_level);
 
     FILE *log_file = fopen("log.txt", "w+");
     log_add_fp(log_file, LOG_WARN);
 }
 
-int virtio_init()
-{
-    // The higher log level is , faster virtio-blk will be.
+int virtio_init() {
+    // The higher log level is, the faster virtio-blk will be.
     int err;
 
-	sigset_t block_mask;
-	sigfillset(&block_mask);
-	pthread_sigmask(SIG_BLOCK, &block_mask, NULL);
+    // Define signal set and add all signals to the set
+    sigset_t block_mask;
+    sigfillset(&block_mask);
+    pthread_sigmask(SIG_BLOCK, &block_mask, NULL);
 
+    // Set process name
     prctl(PR_SET_NAME, "hvisor-virtio", 0, 0, 0);
-	multithread_log_init();
+
+    // Initialize logging
+    multithread_log_init();
     initialize_log();
 
     log_info("hvisor init");
@@ -791,6 +973,7 @@ int virtio_init()
         exit(1);
     }
     // ioctl for init virtio
+    // Communicate with hvisor kernel module
     err = ioctl(ko_fd, HVISOR_INIT_VIRTIO);
     if (err) {
         log_error("ioctl failed, err code is %d", err);
@@ -799,70 +982,108 @@ int virtio_init()
     }
 
     // mmap: create shared memory
-    virtio_bridge = (struct virtio_bridge *) mmap(NULL, MMAP_SIZE, PROT_READ | PROT_WRITE, MAP_SHARED, ko_fd, 0);
+    // Map the virtio_bridge set by the kernel module to this space
+    virtio_bridge = (struct virtio_bridge *)mmap(
+        NULL, MMAP_SIZE, PROT_READ | PROT_WRITE, MAP_SHARED, ko_fd, 0);
     if (virtio_bridge == (void *)-1) {
         log_error("mmap failed");
         goto unmap;
     }
 
+    // Initialize event_monitor used by console and net devices
     initialize_event_monitor();
     log_info("hvisor init okay!");
-	return 0;
+    return 0;
 unmap:
     munmap((void *)virtio_bridge, MMAP_SIZE);
     return -1;
 }
 
-static int create_virtio_device_from_json(cJSON* device_json, int zone_id) {
+int create_virtio_device_from_json(cJSON *device_json, int zone_id) {
     VirtioDeviceType dev_type = VirtioTNone;
-	uint64_t base_addr = 0, len = 0;
-	uint32_t irq_id = 0;
+    uint64_t base_addr = 0, len = 0;
+    uint32_t irq_id = 0;
+
+    GPURequestedState *requested_state = NULL;
+
     char *status = cJSON_GetObjectItem(device_json, "status")->valuestring;
-    if (strcmp(status, "disable") == 0) 
+    if (strcmp(status, "disable") == 0)
         return 0;
 
+    // Get device type
     char *type = cJSON_GetObjectItem(device_json, "type")->valuestring;
     void *arg0, *arg1;
 
+    // Match the device type field in json
     if (strcmp(type, "blk") == 0) {
-		dev_type = VirtioTBlock;
-	} else if (strcmp(type, "net") == 0) {
-		dev_type = VirtioTNet;
-	} else if (strcmp(type, "console") == 0) {
+        dev_type = VirtioTBlock;
+    } else if (strcmp(type, "net") == 0) {
+        dev_type = VirtioTNet;
+    } else if (strcmp(type, "console") == 0) {
         dev_type = VirtioTConsole;
+    } else if (strcmp(type, "gpu") == 0) {
+        dev_type = VirtioTGPU;
     } else {
-		log_error("unknown device type %s", type);
-		return -1;
-	}
-    base_addr = strtoul(cJSON_GetObjectItem(device_json, "addr")->valuestring, NULL, 16);
-    len = strtoul(cJSON_GetObjectItem(device_json, "len")->valuestring, NULL, 16);
+        log_error("unknown device type %s", type);
+        return -1;
+    }
+
+    // Get base_addr, len, irq_id (mmio region base address and length, device
+    // interrupt number)
+    base_addr = strtoul(cJSON_GetObjectItem(device_json, "addr")->valuestring,
+                        NULL, 16);
+    len =
+        strtoul(cJSON_GetObjectItem(device_json, "len")->valuestring, NULL, 16);
     irq_id = cJSON_GetObjectItem(device_json, "irq")->valueint;
+
+    // Handle other fields according to the device type
     if (dev_type == VirtioTBlock) {
+        // virtio-blk
         char *img = cJSON_GetObjectItem(device_json, "img")->valuestring;
         arg0 = img, arg1 = NULL;
     } else if (dev_type == VirtioTNet) {
+        // virtio-net
         char *tap = cJSON_GetObjectItem(device_json, "tap")->valuestring;
         cJSON *mac_json = cJSON_GetObjectItem(device_json, "mac");
         uint8_t mac[6];
-        for (int i=0; i<6; i++) {
-            mac[i] = strtoul(cJSON_GetArrayItem(mac_json, i)->valuestring, NULL, 16);
+        for (int i = 0; i < 6; i++) {
+            mac[i] =
+                strtoul(cJSON_GetArrayItem(mac_json, i)->valuestring, NULL, 16);
         }
         arg0 = mac, arg1 = tap;
     } else if (dev_type == VirtioTConsole) {
+        // virtio-console
         arg0 = arg1 = NULL;
+    } else if (dev_type == VirtioTGPU) {
+        // virtio-gpu
+        // TODO: Add display device settings
+        requested_state =
+            (GPURequestedState *)malloc(sizeof(GPURequestedState));
+        memset(requested_state, 0, sizeof(GPURequestedState));
+        requested_state->width =
+            cJSON_GetObjectItem(device_json, "width")->valueint;
+        requested_state->height =
+            cJSON_GetObjectItem(device_json, "height")->valueint;
+        arg0 = requested_state;
+        arg1 = NULL;
     }
+
+    // Check for missing fields
     if (base_addr == 0 || len == 0 || irq_id == 0) {
-		log_error("missing arguments");
-		return -1;
-	}
-    if(!create_virtio_device(dev_type, zone_id, base_addr, len, irq_id, arg0, arg1)) {
-        log_error("create virtio device failed");
+        log_error("missing arguments");
         return -1;
     }
+
+    // Create virtio_device
+    if (!create_virtio_device(dev_type, zone_id, base_addr, len, irq_id, arg0,
+                              arg1)) {
+        return -1;
+    }
+
     return 0;
 }
 
-static int virtio_start_from_json(char* json_path) {
+int virtio_start_from_json(char *json_path) {
     char *buffer = NULL;
     u_int64_t file_size;
     int zone_id, num_devices = 0, err = 0, num_zones = 0;
@@ -871,8 +1092,9 @@ static int virtio_start_from_json(char* json_path) {
     buffer = read_file(json_path, &file_size);
     buffer[file_size] = '\0';
 
+    // Read zones
     cJSON *root = cJSON_Parse(buffer);
-    cJSON *zones_json = cJSON_GetObjectItem(root, "zones"); 
+    cJSON *zones_json = cJSON_GetObjectItem(root, "zones");
     num_zones = cJSON_GetArraySize(zones_json);
     if (num_zones > MAX_ZONES) {
         log_error("Exceed maximum zone number");
@@ -880,10 +1102,12 @@ static int virtio_start_from_json(char* json_path) {
         goto err_out;
     }
 
-    for(int i=0; i<num_zones; i++) {
+    // Match zone information
+    for (int i = 0; i < num_zones; i++) {
         cJSON *zone_json = cJSON_GetArrayItem(zones_json, i);
         cJSON *zone_id_json = cJSON_GetObjectItem(zone_json, "id");
-        cJSON *memory_region_json = cJSON_GetObjectItem(zone_json, "memory_region");
+        cJSON *memory_region_json =
+            cJSON_GetObjectItem(zone_json, "memory_region");
         cJSON *devices_json = cJSON_GetObjectItem(zone_json, "devices");
         zone_id = zone_id_json->valueint;
         if (zone_id >= MAX_ZONES) {
@@ -892,16 +1116,25 @@ static int virtio_start_from_json(char* json_path) {
             goto err_out;
         }
         int num_mems = cJSON_GetArraySize(memory_region_json);
-        for(int j=0; j<num_mems; j++) {
+
+        // Memory regions
+        for (int j = 0; j < num_mems; j++) {
             cJSON *mem_region = cJSON_GetArrayItem(memory_region_json, j);
-            zone0_ipa = strtoull(cJSON_GetObjectItem(mem_region, "zone0_ipa")->valuestring, NULL, 16);
-            zonex_ipa = strtoull(cJSON_GetObjectItem(mem_region, "zonex_ipa")->valuestring, NULL, 16);
-            mem_size = strtoull(cJSON_GetObjectItem(mem_region, "size")->valuestring, NULL, 16);
+            zone0_ipa = strtoull(
+                cJSON_GetObjectItem(mem_region, "zone0_ipa")->valuestring, NULL,
+                16);
+            zonex_ipa = strtoull(
+                cJSON_GetObjectItem(mem_region, "zonex_ipa")->valuestring, NULL,
+                16);
+            mem_size = strtoull(
+                cJSON_GetObjectItem(mem_region, "size")->valuestring, NULL, 16);
             if (mem_size == 0) {
                 log_error("Invalid memory size");
                 continue;
             }
-            virt_addr = mmap(NULL, mem_size, PROT_READ | PROT_WRITE, MAP_SHARED, ko_fd, (off_t) zone0_ipa);
+            // Map from zone0_ipa
+            virt_addr = mmap(NULL, mem_size, PROT_READ | PROT_WRITE, MAP_SHARED,
+                             ko_fd, (off_t)zone0_ipa);
             if (virt_addr == (void *)-1) {
                 log_error("mmap failed");
                 err = -1;
@@ -912,9 +1145,9 @@ static int virtio_start_from_json(char* json_path) {
             zone_mem[zone_id][j][ZONEX_IPA] = zonex_ipa;
             zone_mem[zone_id][j][MEM_SIZE] = mem_size;
         }
-        
+
         num_devices = cJSON_GetArraySize(devices_json);
-        for (int j=0; j < num_devices; j++) {
+        for (int j = 0; j < num_devices; j++) {
             cJSON *device = cJSON_GetArrayItem(devices_json, j);
             err = create_virtio_device_from_json(device, zone_id);
             if (err) {
@@ -931,23 +1164,27 @@ err_out:
 }
 
 int virtio_start(int argc, char *argv[]) {
-	int opt, err = 0;
-	err = virtio_init();
-    if (err) return -1;
+    int opt, err = 0;
+    err = virtio_init(); // Initialize virtio dependencies
+    if (err)
+        return -1;
 
-    err = virtio_start_from_json(argv[3]);
-    if (err) goto err_out;
+    err = virtio_start_from_json(
+        argv[3]); // Start virtio devices based on virtio_cfg_*.json
+    if (err)
+        goto err_out;
 
-	for (int i=0; i<vdevs_num; i++) {
-		virtio_bridge->mmio_addrs[i] = vdevs[i]->base_addr;	
-	}
-	write_barrier();
-	virtio_bridge->mmio_avail = 1;
-	write_barrier();
-    handle_virtio_requests();
-	return 0;
+    for (int i = 0; i < vdevs_num; i++) {
+        virtio_bridge->mmio_addrs[i] = vdevs[i]->base_addr;
+    }
+
+    write_barrier();
+    virtio_bridge->mmio_avail = 1;
+    write_barrier();
+
+    handle_virtio_requests(); // Handle virtio requests
+    return 0;
 err_out:
-	virtio_close();
-	return err;
+    virtio_close();
+    return err;
 }
-

--- a/tools/virtio_blk.c
+++ b/tools/virtio_blk.c
@@ -162,7 +162,7 @@ static struct blkp_req* virtq_blk_handle_one_request(VirtQueue *vq)
     int i, n;
     BlkReqHead *hdr;
     breq = malloc(sizeof(struct blkp_req));
-    n = process_descriptor_chain(vq, &breq->idx, &iov, &flags, 0);
+    n = process_descriptor_chain(vq, &breq->idx, &iov, &flags, 0, true);
 	breq->iov = iov;
     if (n < 2 || n > BLK_SEG_MAX + 2) {
         log_error("iov's num is wrong, n is %d", n);

--- a/tools/virtio_console.c
+++ b/tools/virtio_console.c
@@ -46,7 +46,7 @@ static void virtio_console_event_handler(int fd, int epoll_type, void *param) {
     }
     
     while (!virtqueue_is_empty(vq)) {
-        n = process_descriptor_chain(vq, &idx, &iov, NULL, 0);
+        n = process_descriptor_chain(vq, &idx, &iov, NULL, 0, false);
         if (n < 1) {
             log_error("process_descriptor_chain failed");
             break;
@@ -141,7 +141,7 @@ static void virtq_tx_handle_one_request(ConsoleDev *dev, VirtQueue *vq) {
         return ;
     }
 
-    n = process_descriptor_chain(vq, &idx, &iov, NULL, 0);
+    n = process_descriptor_chain(vq, &idx, &iov, NULL, 0, false);
     // if (count % 100 == 0) {
     //     log_info("console txq: n is %d, data is ", n);
     //     for (int i=0; i<iov->iov_len; i++)

--- a/tools/virtio_gpu.c
+++ b/tools/virtio_gpu.c
@@ -1,0 +1,855 @@
+#include "virtio_gpu.h"
+#include "linux/stddef.h"
+#include "linux/types.h"
+#include "linux/virtio_gpu.h"
+#include "log.h"
+#include "sys/queue.h"
+#include "virtio.h"
+#include <drm/drm.h>
+#include <drm/drm_fourcc.h>
+#include <drm/drm_mode.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <time.h>
+#include <xf86drm.h>
+#include <xf86drmMode.h>
+
+void virtio_gpu_ctrl_response(VirtIODevice *vdev, GPUCommand *gcmd,
+                              GPUControlHeader *resp, size_t resp_len) {
+    log_debug("sending response");
+    // Since the header of each response structure is GPUControlHeader, its
+    // address is the address of the response structure
+
+    // The first descriptor corresponding to iov[0] is always read-only, so
+    // start from the second one
+    size_t s = buf_to_iov(&gcmd->resp_iov[1], gcmd->resp_iov_cnt - 1, 0, resp,
+                          resp_len);
+
+    if (s != resp_len) {
+        log_error("%s cannot copy buffer to iov with correct size", __func__);
+        // Continue to return, let the front end handle it
+    }
+
+    update_used_ring(&vdev->vqs[gcmd->from_queue], gcmd->resp_idx, resp_len);
+
+    gcmd->finished = true;
+}
+
+void virtio_gpu_ctrl_response_nodata(VirtIODevice *vdev, GPUCommand *gcmd,
+                                     enum virtio_gpu_ctrl_type type) {
+    log_debug("entering %s", __func__);
+
+    GPUControlHeader resp;
+
+    memset(&resp, 0, sizeof(resp));
+    resp.type = type;
+    virtio_gpu_ctrl_response(vdev, gcmd, &resp, sizeof(resp));
+}
+
+void virtio_gpu_get_display_info(VirtIODevice *vdev, GPUCommand *gcmd) {
+    log_debug("entering %s", __func__);
+
+    struct virtio_gpu_resp_display_info display_info;
+    GPUDev *gdev = vdev->dev;
+
+    memset(&display_info, 0, sizeof(display_info));
+    display_info.hdr.type = VIRTIO_GPU_RESP_OK_DISPLAY_INFO;
+
+    // Fill the response structure with display information
+    for (int i = 0; i < HVISOR_VIRTIO_GPU_MAX_SCANOUTS; ++i) {
+        if (gdev->enabled_scanout_bitmask & (1 << i)) {
+            display_info.pmodes[i].enabled = 1;
+            display_info.pmodes[i].r.width = gdev->requested_states[i].width;
+            display_info.pmodes[i].r.height = gdev->requested_states[i].height;
+            log_debug(
+                "return display info of scanout %d with width %d, height %d", i,
+                display_info.pmodes[i].r.width,
+                display_info.pmodes[i].r.height);
+        }
+    }
+
+    virtio_gpu_ctrl_response(vdev, gcmd, &display_info.hdr,
+                             sizeof(display_info));
+}
+
+void virtio_gpu_get_edid(VirtIODevice *vdev, GPUCommand *gcmd) {
+    log_debug("entering %s", __func__);
+    // TODO: Implement this function
+}
+
+void virtio_gpu_resource_create_2d(VirtIODevice *vdev, GPUCommand *gcmd) {
+    log_debug("entering %s", __func__);
+
+    GPUSimpleResource *res = NULL;
+    GPUDev *gdev = vdev->dev;
+    struct virtio_gpu_resource_create_2d create_2d;
+
+    VIRTIO_GPU_FILL_CMD(gcmd->resp_iov, gcmd->resp_iov_cnt, create_2d);
+
+    // Check if the resource_id to be created is 0 (cannot use 0)
+    if (create_2d.resource_id == 0) {
+        log_error("%s trying to create 2d resource with id 0", __func__);
+        gcmd->error = VIRTIO_GPU_RESP_ERR_INVALID_RESOURCE_ID;
+        return;
+    }
+
+    // Check if the resource has already been created
+    res = virtio_gpu_find_resource(gdev, create_2d.resource_id);
+    if (res) {
+        log_error("%s trying to create an existing resource with id %d",
+                  __func__, create_2d.resource_id);
+        gcmd->error = VIRTIO_GPU_RESP_ERR_INVALID_RESOURCE_ID;
+        return;
+    }
+
+    // Otherwise, create a new resource
+    res = calloc(1, sizeof(GPUSimpleResource));
+    memset(res, 0, sizeof(GPUSimpleResource));
+
+    res->width = create_2d.width;
+    res->height = create_2d.height;
+    res->format = create_2d.format;
+    res->resource_id = create_2d.resource_id;
+    res->scanout_bitmask = 0;
+    res->iov = NULL;
+    res->iov_cnt = 0;
+
+    // Calculate the memory size occupied by the resource
+    // By default, only formats with 4 bytes per pixel are supported
+    res->hostmem = calc_image_hostmem(32, create_2d.width, create_2d.height);
+    if (res->hostmem + gdev->hostmem >= VIRTIO_GPU_MAX_HOSTMEM) {
+        log_error("virtio gpu for zone %d out of hostmem when trying to create "
+                  "resource %d",
+                  vdev->zone_id, create_2d.resource_id);
+        free(res);
+        return;
+    }
+
+    // If memory is sufficient, add the resource to the virtio gpu management
+    TAILQ_INSERT_HEAD(&gdev->resource_list, res, next);
+    gdev->hostmem += res->hostmem;
+
+    log_debug("add a resource %d to gpu dev of zone %d, width: %d height: %d "
+              "format: %d mem: %d bytes host-hostmem: %d bytes",
+              res->resource_id, vdev->zone_id, res->width, res->height,
+              res->format, res->hostmem, gdev->hostmem);
+}
+
+GPUSimpleResource *virtio_gpu_find_resource(GPUDev *gdev,
+                                            uint32_t resource_id) {
+    GPUSimpleResource *temp_res = NULL;
+    TAILQ_FOREACH(temp_res, &gdev->resource_list, next) {
+        if (temp_res->resource_id == resource_id) {
+            return temp_res;
+        }
+    }
+    return NULL;
+}
+
+GPUSimpleResource *virtio_gpu_check_resource(VirtIODevice *vdev,
+                                             uint32_t resource_id,
+                                             const char *caller,
+                                             uint32_t *error) {
+    GPUSimpleResource *res = NULL;
+    GPUDev *gdev = vdev->dev;
+
+    res = virtio_gpu_find_resource(gdev, resource_id);
+    if (!res) {
+        log_error("%s cannot find resource by id %d", caller, resource_id);
+        if (error) {
+            *error = VIRTIO_GPU_RESP_ERR_INVALID_RESOURCE_ID;
+        }
+        return NULL;
+    }
+
+    if (!res->iov || res->hostmem <= 0) {
+        log_error("%s found resource %d has no backing storage", caller,
+                  resource_id);
+        if (error) {
+            *error = VIRTIO_GPU_RESP_ERR_UNSPEC;
+        }
+        return NULL;
+    }
+
+    return res;
+}
+
+uint32_t calc_image_hostmem(int bits_per_pixel, uint32_t width,
+                            uint32_t height) {
+    // 0x1f = 31, >> 5 is equivalent to dividing by 32, aligning the bits per
+    // row to a multiple of 4 bytes
+    // Finally, multiply by sizeof(uint32) to get the number of bytes
+    int stride = ((width * bits_per_pixel + 0x1f) >> 5) * sizeof(uint32_t);
+    // Return the total memory size
+    return height * stride;
+}
+
+void virtio_gpu_resource_unref(VirtIODevice *vdev, GPUCommand *gcmd) {
+    log_debug("entering %s", __func__);
+
+    GPUDev *gdev = vdev->dev;
+
+    GPUSimpleResource *res = NULL;
+    struct virtio_gpu_resource_unref unref;
+
+    VIRTIO_GPU_FILL_CMD(gcmd->resp_iov, gcmd->resp_iov_cnt, unref);
+
+    res = virtio_gpu_find_resource(gdev, unref.resource_id);
+    if (!res) {
+        log_error("%s cannot find resource %d", __func__, unref.resource_id);
+        gcmd->error = VIRTIO_GPU_RESP_ERR_INVALID_RESOURCE_ID;
+        return;
+    }
+
+    virtio_gpu_resource_destory(gdev, res);
+}
+
+void virtio_gpu_resource_destory(GPUDev *gdev, GPUSimpleResource *res) {
+    if (res->scanout_bitmask) {
+        for (int i = 0; i < HVISOR_VIRTIO_GPU_MAX_SCANOUTS; ++i) {
+            if (res->scanout_bitmask & (1 << i)) {
+                virtio_gpu_disable_scanout(gdev, i);
+            }
+        }
+    }
+
+    virtio_gpu_cleanup_mapping(gdev, res);
+    TAILQ_REMOVE(&gdev->resource_list, res, next);
+    gdev->hostmem -= res->hostmem;
+    free(res);
+}
+
+void virtio_gpu_disable_scanout(GPUDev *gdev, int scanout_id) {
+    GPUScanout *scanout = &gdev->scanouts[scanout_id];
+    GPUSimpleResource *res = NULL;
+
+    if (scanout->resource_id == 0) {
+        return;
+    }
+
+    res = virtio_gpu_find_resource(gdev, scanout->resource_id);
+    if (res) {
+        res->scanout_bitmask &= ~(1 << scanout_id);
+    }
+
+    scanout->resource_id = 0;
+    scanout->width = 0;
+    scanout->height = 0;
+}
+
+void virtio_gpu_cleanup_mapping(GPUDev *gdev, GPUSimpleResource *res) {
+    if (res->iov) {
+        free(res->iov);
+        // The memory block corresponding to iov is handled by the guest
+    }
+
+    res->iov = NULL;
+    res->iov_cnt = 0;
+}
+
+void virtio_gpu_resource_flush(VirtIODevice *vdev, GPUCommand *gcmd) {
+    log_debug("entering %s", __func__);
+
+    GPUDev *gdev = vdev->dev;
+
+    GPUSimpleResource *res = NULL;
+    GPUScanout *scanout = NULL;
+    struct virtio_gpu_resource_flush resource_flush;
+
+    VIRTIO_GPU_FILL_CMD(gcmd->resp_iov, gcmd->resp_iov_cnt, resource_flush);
+
+    res = virtio_gpu_check_resource(vdev, resource_flush.resource_id, __func__,
+                                    &gcmd->error);
+    if (!res) {
+        return;
+    }
+
+    if (resource_flush.r.x > res->width || resource_flush.r.y > res->height ||
+        resource_flush.r.width > res->width ||
+        resource_flush.r.height > res->height ||
+        resource_flush.r.x + resource_flush.r.width > res->width ||
+        resource_flush.r.y + resource_flush.r.height > res->height) {
+        log_error(
+            "%s flush bounds outside resource %d bounds, (%d, %d) + %d, %d "
+            "vs %d, %d",
+            __func__, resource_flush.resource_id, resource_flush.r.x,
+            resource_flush.r.y, resource_flush.r.width, resource_flush.r.height,
+            res->width, res->height);
+        gcmd->error = VIRTIO_GPU_RESP_ERR_INVALID_PARAMETER;
+        return;
+    }
+
+    for (int i = 0; i < HVISOR_VIRTIO_GPU_MAX_SCANOUTS; ++i) {
+        // Traverse the scanouts corresponding to the resource
+        if (!(res->scanout_bitmask & (1 << i))) {
+            continue;
+        }
+        scanout = &gdev->scanouts[i];
+
+        if (!scanout->frame_buffer.enabled) {
+            virtio_gpu_create_drm_framebuffer(scanout, &gcmd->error);
+            if (gcmd->error) {
+                return;
+            }
+
+            virtio_gpu_copy_and_flush(scanout, res, &gcmd->error);
+        } else {
+            // TODO: If the framebuffer has already been allocated once and the
+            // size is not suitable, it needs to be reallocated
+            // TODO: This includes calling munmap and the drm destroy function
+            // TODO: Encapsulate the case where it has not been allocated
+
+            virtio_gpu_copy_and_flush(scanout, res, &gcmd->error);
+        }
+    }
+}
+
+void virtio_gpu_create_drm_framebuffer(GPUScanout *scanout, uint32_t *error) {
+    if (scanout->frame_buffer.enabled) {
+        return;
+    }
+
+    // If the scanout's frame_buffer has not been initialized yet
+    GPUFrameBuffer *fb = &scanout->frame_buffer;
+
+    struct drm_mode_create_dumb dumb = {0};
+    struct drm_mode_map_dumb map = {0};
+    dumb.width = fb->width;
+    dumb.height = fb->height;
+    dumb.bpp = fb->bytes_pp * 8;
+    uint32_t offsets[4] = {0};
+    uint32_t fb_id = 0;
+
+    if (drmIoctl(scanout->card0_fd, DRM_IOCTL_MODE_CREATE_DUMB, &dumb) < 0) {
+        log_error("%s failed to create a drm dumb", __func__);
+        *error = VIRTIO_GPU_RESP_ERR_UNSPEC;
+        return;
+    } // Create a dumb object
+
+    map.handle = dumb.handle;
+    // Bind the video memory to the framebuffer, get the offset based on the
+    // handle
+    if (drmIoctl(scanout->card0_fd, DRM_IOCTL_MODE_MAP_DUMB, &map) < 0) {
+        log_error("%s failed to map a drm dumb", __func__);
+        virtio_gpu_remove_drm_framebuffer(scanout);
+        *error = VIRTIO_GPU_RESP_ERR_UNSPEC;
+        return;
+    }
+
+    // ! legacy
+    // uint32_t drm_format = VIRTIO_GPU_FORMAT_TO_DRM_FORMAT(fb->format);
+    // if (!drm_format) {
+    //   log_error("%s found drm_framebuffer has an unknown format", __func__);
+    //   *error = VIRTIO_GPU_RESP_ERR_UNSPEC;
+    //   return;
+    // }
+
+    // ! legacy
+    // if (drmModeAddFB2(scanout->card0_fd, dumb.width, dumb.height, drm_format,
+    //                   &dumb.handle, &dumb.pitch, offsets, &fb_id, 0) < 0) {
+    //   log_error("%s failed to add a drm_framebuffer to card0", __func__);
+    //   *error = VIRTIO_GPU_RESP_ERR_UNSPEC;
+    //   return;
+    // }
+
+    if (drmModeAddFB(scanout->card0_fd, dumb.width, dumb.height, 24, 32,
+                     dumb.pitch, dumb.handle, &fb_id) < 0) {
+        log_error("%s failed to add a drm_framebuffer to card0", __func__);
+        *error = VIRTIO_GPU_RESP_ERR_UNSPEC;
+        return;
+    }
+
+    ///
+    log_debug("%s create a drm_framebuffer with width: %d, height: %d, "
+              "format: %d, handle: %d, fb_id: %d",
+              __func__, dumb.width, dumb.height, fb->format, dumb.handle,
+              fb_id);
+    ///
+
+    void *vaddr = mmap(0, dumb.size, PROT_READ | PROT_WRITE, MAP_SHARED,
+                       scanout->card0_fd, map.offset);
+
+    if (!vaddr) {
+        log_error("%s cannot map drm_framebuffer of scanout", __func__);
+        virtio_gpu_remove_drm_framebuffer(scanout);
+        *error = VIRTIO_GPU_RESP_ERR_UNSPEC;
+        return;
+    }
+
+    log_debug("%s map drm_framebuffer to %x with size %d", __func__, vaddr,
+              dumb.size);
+
+    fb->fb_id = fb_id;
+    fb->drm_dumb_handle = dumb.handle;
+    fb->drm_dumb_size = dumb.size;
+    fb->fb_addr = vaddr;
+    fb->enabled = true;
+}
+
+void virtio_gpu_copy_and_flush(GPUScanout *scanout, GPUSimpleResource *res,
+                               uint32_t *error) {
+
+    uint32_t format = 0;
+    uint32_t stride = 0;
+    uint32_t src_offset = 0;
+    uint32_t dst_offset = 0;
+    int bpp = 0;
+
+    GPUFrameBuffer *fb = &scanout->frame_buffer;
+
+    if (!res || !res->iov || res->hostmem <= 0) {
+        log_error("%s found res is not create yet");
+        *error = VIRTIO_GPU_RESP_ERR_UNSPEC;
+        return;
+    }
+
+    if (!fb || !fb->enabled || !fb->fb_addr) {
+        log_error("%s found drm_framebuffer is not enabled yet");
+        *error = VIRTIO_GPU_RESP_ERR_UNSPEC;
+        return;
+    }
+
+    format = res->format;
+    bpp = 32;
+    stride = res->hostmem / res->height;
+
+    // Copy data from resource to framebuffer
+    if (res->transfer_rect.x || res->transfer_rect.width != res->width) {
+        for (int h = 0; h < res->transfer_rect.height; h++) {
+            src_offset = res->transfer_offset + stride * h;
+            dst_offset = (res->transfer_rect.y + h) * stride +
+                         (res->transfer_rect.x * bpp);
+
+            size_t s = iov_to_buf(res->iov, res->iov_cnt, src_offset,
+                                  fb->fb_addr + dst_offset,
+                                  res->transfer_rect.width * bpp);
+
+            // debug
+            log_debug("%s copy %d bytes from resource %d to drm_framebuffer, "
+                      "src_offset: %d, dst_offset: %d",
+                      __func__, s, res->resource_id, src_offset, dst_offset);
+        }
+    } else {
+        src_offset = res->transfer_offset;
+        dst_offset = res->transfer_rect.y * stride + res->transfer_rect.x * bpp;
+
+        size_t s = iov_to_buf(res->iov, res->iov_cnt, src_offset,
+                              fb->fb_addr + dst_offset,
+                              stride * res->transfer_rect.height);
+
+        // debug
+        log_debug("%s copy %d bytes from resource %d to drm_framebuffer, "
+                  "src_offset: %d, dst_offset: %d",
+                  __func__, s, res->resource_id, src_offset, dst_offset);
+    }
+
+    drmModeModeInfo mode = scanout->connector->modes[0];
+    drmModeSetCrtc(scanout->card0_fd, scanout->crtc->crtc_id, fb->fb_id, 0, 0,
+                   &scanout->connector->connector_id, 1, &mode);
+
+    log_debug("%s flush with card0_fd: %d, crtc_id: %d, fb_id: %d, "
+              "connector_id: %d",
+              __func__, scanout->card0_fd, scanout->crtc->crtc_id, fb->fb_id,
+              scanout->connector->connector_id);
+}
+
+void virtio_gpu_remove_drm_framebuffer(GPUScanout *scanout) {
+    GPUFrameBuffer *fb = &scanout->frame_buffer;
+
+    if (!fb || !fb->enabled || !fb->fb_addr) {
+        log_error("%s found drm_framebuffer is not enabled yet");
+        return;
+    }
+
+    struct drm_mode_destroy_dumb destory = {0};
+    destory.handle = fb->drm_dumb_handle;
+
+    drmModeRmFB(scanout->card0_fd, fb->fb_id);
+    if (fb->fb_addr != NULL) {
+        munmap(fb->fb_addr, fb->drm_dumb_size);
+    }
+    drmIoctl(scanout->card0_fd, DRM_IOCTL_MODE_DESTROY_DUMB, &destory);
+
+    log_debug("%s destoryed drm_framebuffer with id: %d, handle: %d, size: %d",
+              __func__, fb->fb_id, fb->drm_dumb_handle, fb->drm_dumb_size);
+
+    // Reserve others
+    fb->fb_id = 0;
+    fb->drm_dumb_handle = 0;
+    fb->drm_dumb_size = 0;
+    fb->fb_addr = NULL;
+    fb->enabled = false;
+}
+
+void virtio_gpu_set_scanout(VirtIODevice *vdev, GPUCommand *gcmd) {
+    log_debug("entering %s", __func__);
+
+    GPUDev *gdev = vdev->dev;
+
+    GPUSimpleResource *res = NULL;
+    GPUFrameBuffer fb = {0};
+    struct virtio_gpu_set_scanout set_scanout;
+
+    VIRTIO_GPU_FILL_CMD(gcmd->resp_iov, gcmd->resp_iov_cnt, set_scanout);
+
+    // Check scanout id
+    if (set_scanout.scanout_id >= gdev->scanouts_num) {
+        log_error("%s setting invalid scanout with scanout_id %d", __func__,
+                  set_scanout.scanout_id);
+        gcmd->error = VIRTIO_GPU_RESP_ERR_INVALID_SCANOUT_ID;
+        return;
+    }
+
+    res = virtio_gpu_check_resource(vdev, set_scanout.resource_id, __func__,
+                                    &gcmd->error);
+    if (!res) {
+        return;
+    }
+
+    log_debug("%s setting scanout %d with resource %d", __func__,
+              set_scanout.scanout_id, set_scanout.resource_id);
+
+    fb.format = res->format;
+    fb.bytes_pp = 4; // All formats are 4 bytes pp (32 bytes per pixel)
+    fb.width = res->width;
+    fb.height = res->height;
+    fb.stride = res->hostmem / res->height; // hostmem = height * stride
+    fb.offset = set_scanout.r.x * fb.bytes_pp + set_scanout.r.y * fb.stride;
+    fb.fb_addr = NULL;
+    fb.enabled = false;
+
+    virtio_gpu_do_set_scanout(vdev, set_scanout.scanout_id, &fb, res,
+                              &set_scanout.r, &gcmd->error);
+}
+
+bool virtio_gpu_do_set_scanout(VirtIODevice *vdev, uint32_t scanout_id,
+                               GPUFrameBuffer *fb, GPUSimpleResource *res,
+                               struct virtio_gpu_rect *r, uint32_t *error) {
+    GPUDev *gdev = vdev->dev;
+    GPUScanout *scanout = NULL;
+
+    scanout = &gdev->scanouts[scanout_id];
+
+    if (r->x > fb->width || r->y > fb->width || r->width < 16 ||
+        r->height < 16 || r->width > fb->width || r->height > fb->height ||
+        r->x + r->width > fb->width || r->y + r->height > fb->height) {
+        log_error(
+            "%s found illegal scanout %d bounds for resource %d, rect (%d, "
+            "%d) + %d, %d, fb %d, %d",
+            __func__, scanout_id, res->resource_id, r->x, r->y, r->width,
+            r->height, fb->width, fb->height);
+        *error = VIRTIO_GPU_RESP_ERR_INVALID_PARAMETER;
+        return false;
+    }
+
+    log_debug(
+        "%s set scanout display region (%d, %d) + %d, %d, with framebuffer "
+        "%d, %d",
+        __func__, r->x, r->y, r->width, r->height, fb->width, fb->height);
+
+    // TODO: Blob related logic (if VIRTIO_GPU_F_RESOURCE_BLOB feature is
+    // supported)
+
+    // Update scanout
+    virtio_gpu_update_scanout(vdev, scanout_id, fb, res, r);
+    return true;
+}
+
+void virtio_gpu_update_scanout(VirtIODevice *vdev, uint32_t scanout_id,
+                               GPUFrameBuffer *fb, GPUSimpleResource *res,
+                               struct virtio_gpu_rect *r) {
+    GPUDev *gdev = vdev->dev;
+    GPUSimpleResource *origin_res = NULL;
+    GPUScanout *scanout = NULL;
+
+    scanout = &gdev->scanouts[scanout_id];
+    origin_res = virtio_gpu_find_resource(gdev, scanout->resource_id);
+    if (origin_res) {
+        // Unbind the original resource
+        origin_res->scanout_bitmask &= ~(1 << scanout_id);
+    }
+
+    // Bind the new resource
+    res->scanout_bitmask |= (1 << scanout_id);
+    log_debug("%s updated scanout %d to resource %d", __func__, scanout_id,
+              res->resource_id);
+
+    // Update scanout parameters and framebuffer
+    scanout->resource_id = res->resource_id;
+    scanout->x = r->x;
+    scanout->y = r->y;
+    scanout->width = r->width;
+    scanout->height = r->height;
+    scanout->frame_buffer = *fb;
+}
+
+void virtio_gpu_transfer_to_host_2d(VirtIODevice *vdev, GPUCommand *gcmd) {
+    log_debug("entering %s", __func__);
+
+    GPUDev *gdev = vdev->dev;
+
+    GPUSimpleResource *res = NULL;
+    uint32_t src_offset = 0;
+    uint32_t dst_offset = 0;
+    struct virtio_gpu_transfer_to_host_2d transfer_2d;
+
+    VIRTIO_GPU_FILL_CMD(gcmd->resp_iov, gcmd->resp_iov_cnt, transfer_2d);
+
+    res = virtio_gpu_check_resource(vdev, transfer_2d.resource_id, __func__,
+                                    &gcmd->error);
+    if (!res) {
+        return;
+    }
+
+    if (transfer_2d.r.x > res->width || transfer_2d.r.y > res->height ||
+        transfer_2d.r.width > res->width ||
+        transfer_2d.r.height > res->height ||
+        transfer_2d.r.x + transfer_2d.r.width > res->width ||
+        transfer_2d.r.y + transfer_2d.r.height > res->height) {
+        log_error(
+            "%s trying to transfer bounds outside resource %d bounds, (%d, "
+            "%d) + %d, %d vs %d, %d",
+            __func__, res->resource_id, transfer_2d.r.x, transfer_2d.r.y,
+            transfer_2d.r.width, transfer_2d.r.height, res->width, res->height);
+        gcmd->error = VIRTIO_GPU_RESP_ERR_INVALID_PARAMETER;
+        return;
+    }
+
+    log_debug(
+        "%s transfering a region (%d, %d) + %d, %d from resource %d %d, %d",
+        __func__, transfer_2d.r.x, transfer_2d.r.y, transfer_2d.r.width,
+        transfer_2d.r.height, res->resource_id, res->width, res->height);
+
+    // Retain transfer information, and perform the actual copy during flush
+    res->transfer_rect.x = transfer_2d.r.x;
+    res->transfer_rect.y = transfer_2d.r.y;
+    res->transfer_rect.width = transfer_2d.r.width;
+    res->transfer_rect.height = transfer_2d.r.height;
+    res->transfer_offset = transfer_2d.offset;
+}
+
+void virtio_gpu_resource_attach_backing(VirtIODevice *vdev, GPUCommand *gcmd) {
+    log_debug("entering %s", __func__);
+
+    GPUSimpleResource *res = NULL;
+    struct virtio_gpu_resource_attach_backing attach_backing;
+    GPUDev *gdev = vdev->dev;
+
+    VIRTIO_GPU_FILL_CMD(gcmd->resp_iov, gcmd->resp_iov_cnt, attach_backing);
+
+    // Check if the resource to be attached is already registered
+    res = virtio_gpu_find_resource(gdev, attach_backing.resource_id);
+    if (!res) {
+        log_error("%s cannot find resource with id %d", __func__,
+                  attach_backing.resource_id);
+        gcmd->error = VIRTIO_GPU_RESP_ERR_INVALID_RESOURCE_ID;
+        return;
+    }
+
+    if (res->iov) {
+        log_error("%s found resource %d already has iov", __func__,
+                  attach_backing.resource_id);
+        gcmd->error = VIRTIO_GPU_RESP_ERR_UNSPEC;
+        return;
+    }
+
+    log_debug("attaching guest mem to resource %d of gpu dev from zone %d",
+              res->resource_id, vdev->zone_id);
+
+    int err = virtio_gpu_create_mapping_iov(vdev, attach_backing.nr_entries,
+                                            sizeof(attach_backing), gcmd,
+                                            &res->iov, &res->iov_cnt);
+    if (err != 0) {
+        log_error("%s failed to map guest memory to iov", __func__);
+        gcmd->error = VIRTIO_GPU_RESP_ERR_UNSPEC;
+        return;
+    }
+}
+
+int virtio_gpu_create_mapping_iov(VirtIODevice *vdev, uint32_t nr_entries,
+                                  uint32_t offset,
+                                  GPUCommand *gcmd, /*uint64_t **addr,*/
+                                  struct iovec **iov, uint32_t *niov) {
+    log_debug("entering %s", __func__);
+    GPUDev *gdev = vdev->dev;
+
+    struct virtio_gpu_mem_entry *entries =
+        NULL; // Array to store all guest memory entries
+    size_t entries_size = 0;
+    int e = 0;
+    int v = 0;
+
+    if (nr_entries > 16384) {
+        log_error("%s found number of entries %d is too big (need to be less "
+                  "than 16384)",
+                  __func__, nr_entries);
+        return -1;
+    }
+
+    // Allocate memory and manage guest memory with iov
+    // Guest memory to host memory requires a layer of conversion
+    entries_size = sizeof(*entries) * nr_entries;
+    entries = malloc(entries_size);
+    log_debug("%s got %d entries with total size %d", __func__, nr_entries,
+              entries_size);
+    // First copy all memory entries attached to the request to entries
+    size_t s = iov_to_buf(gcmd->resp_iov, gcmd->resp_iov_cnt, offset, entries,
+                          entries_size);
+    if (s != entries_size) {
+        log_error("%s failed to copy memory entries to buffer", __func__);
+        free(entries);
+        return -1;
+    }
+
+    *iov = NULL;
+    // if (addr) {
+    //   *addr = NULL;
+    // }
+
+    for (e = 0, v = 0; e < nr_entries; ++e, ++v) {
+        uint64_t e_addr =
+            entries[e].addr; // Starting position of the guest memory block
+        uint32_t e_length =
+            entries[e].length; // Length of the guest memory block
+
+        // Since all memory of zonex will be mapped to zone0
+        // And when zone starts, all memory of zonex will be mapped to the
+        // virtual memory space of hvisor-tool
+        // Therefore, here we only need to manage the virtual address of the
+        // memory block used by zonex to store resource data with iov
+
+        // Allocate iov in groups of 16, if not enough, reallocate memory
+        if (!(v % 16)) {
+            struct iovec *temp = realloc(*iov, (v + 16) * sizeof(struct iovec));
+            if (temp == NULL) {
+                // Unable to allocate
+                log_error("%s cannot allocate enough memory for iov", __func__);
+                free(*iov); // Directly free the iov array
+                free(entries);
+                *iov = NULL;
+                return -1;
+            }
+            *iov = temp;
+            // if (addr) {
+            //   *addr = realloc(*addr, (v * 16) * sizeof(uint64_t));
+            // }
+        }
+
+        (*iov)[v].iov_base = get_virt_addr((void *)e_addr, vdev->zone_id);
+        (*iov)[v].iov_len = e_length;
+        log_debug("guest addr %x map to %x with size %d", e_addr,
+                  (*iov)[v].iov_base, (*iov)[v].iov_len);
+        // if (addr) {
+        //   (*addr)[v] = e_addr;
+        // }
+
+        // Considering that in future changes, the mapping from zonex to zone0
+        // may not be direct, but through dma or other methods
+        // Therefore, keep e and v to deal with the situation where entries and
+        // iov do not correspond one-to-one
+    }
+    *niov = v;
+    log_debug("%d memory blocks mapped", *niov);
+
+    // Free entries
+    free(entries);
+
+    return 0;
+}
+
+// ! reserved
+// void virtio_gpu_cleanup_mapping_iov(GPUDev *gdev, struct iovec *iov,
+//                                     uint32_t iov_cnt) {}
+
+void virtio_gpu_resource_detach_backing(VirtIODevice *vdev, GPUCommand *gcmd) {
+    log_debug("entering %s", __func__);
+
+    GPUDev *gdev = vdev->dev;
+
+    GPUSimpleResource *res = NULL;
+    struct virtio_gpu_resource_detach_backing detach;
+
+    VIRTIO_GPU_FILL_CMD(gcmd->resp_iov, gcmd->resp_iov_cnt, detach);
+
+    res = virtio_gpu_check_resource(vdev, detach.resource_id, __func__,
+                                    &gcmd->error);
+    if (!res) {
+        return;
+    }
+
+    virtio_gpu_cleanup_mapping(gdev, res);
+}
+
+void virtio_gpu_simple_process_cmd(GPUCommand *gcmd, VirtIODevice *vdev) {
+    log_debug("------ entering %s ------", __func__);
+
+    gcmd->error = 0;
+    gcmd->finished = false;
+
+    // First fill in the cmd_hdr that each request has
+    VIRTIO_GPU_FILL_CMD(gcmd->resp_iov, gcmd->resp_iov_cnt,
+                        gcmd->control_header);
+
+    // Jump to the corresponding processing function according to the type of
+    // cmd_hdr
+    /**********************************
+     * The general 2D rendering call chain is
+     * get_display_info->resource_create_2d->resource_attach_backing->set_scanout->get_display_info
+     * (to determine if the setting is successful)
+     * ->transfer_to_host_2d->resource_flush->*repeat transfer and flush*->end
+     */
+    switch (gcmd->control_header.type) {
+    case VIRTIO_GPU_CMD_GET_DISPLAY_INFO:
+        virtio_gpu_get_display_info(vdev, gcmd);
+        break;
+    case VIRTIO_GPU_CMD_GET_EDID:
+        virtio_gpu_get_edid(vdev, gcmd);
+        break;
+    case VIRTIO_GPU_CMD_RESOURCE_CREATE_2D:
+        virtio_gpu_resource_create_2d(vdev, gcmd);
+        break;
+    case VIRTIO_GPU_CMD_RESOURCE_UNREF:
+        virtio_gpu_resource_unref(vdev, gcmd);
+        break;
+    case VIRTIO_GPU_CMD_RESOURCE_FLUSH:
+        virtio_gpu_resource_flush(vdev, gcmd);
+        break;
+    case VIRTIO_GPU_CMD_TRANSFER_TO_HOST_2D:
+        virtio_gpu_transfer_to_host_2d(vdev, gcmd);
+        break;
+    case VIRTIO_GPU_CMD_SET_SCANOUT:
+        virtio_gpu_set_scanout(vdev, gcmd);
+        break;
+    case VIRTIO_GPU_CMD_RESOURCE_ATTACH_BACKING:
+        virtio_gpu_resource_attach_backing(vdev, gcmd);
+        break;
+    case VIRTIO_GPU_CMD_RESOURCE_DETACH_BACKING:
+        virtio_gpu_resource_detach_backing(vdev, gcmd);
+        break;
+    default:
+        log_error("unknown request type");
+        gcmd->error = VIRTIO_GPU_RESP_ERR_UNSPEC;
+        break;
+    }
+
+    if (!gcmd->finished) {
+        // If no response with data is returned directly, check for errors and
+        // return a response without data
+        if (gcmd->error) {
+            log_error(
+                "failed to handle virtio gpu request from zone %d, and request "
+                "type is %d, error type is %d",
+                vdev->zone_id, gcmd->control_header.type, gcmd->error);
+        }
+        virtio_gpu_ctrl_response_nodata(
+            vdev, gcmd, gcmd->error ? gcmd->error : VIRTIO_GPU_RESP_OK_NODATA);
+    }
+
+    // Processing is complete, no need for iov
+    free(gcmd->resp_iov);
+
+    log_debug("------ leaving %s ------", __func__);
+}

--- a/tools/virtio_gpu_async.c
+++ b/tools/virtio_gpu_async.c
@@ -1,0 +1,65 @@
+#include "log.h"
+#include "sys/queue.h"
+#include "virtio.h"
+#include "virtio_gpu.h"
+#include <pthread.h>
+#include <stdlib.h>
+
+void *virtio_gpu_handler(void *dev) {
+    VirtIODevice *vdev = (VirtIODevice *)dev;
+    GPUDev *gdev = vdev->dev;
+    GPUCommand *gcmd = NULL;
+
+    uint32_t request_cnt = 0;
+
+    pthread_mutex_lock(&gdev->queue_mutex);
+    for (;;) {
+        // Check if the device is closed
+        if (gdev->close) {
+            pthread_mutex_unlock(&gdev->queue_mutex);
+            pthread_exit(NULL);
+            return NULL;
+        }
+
+        // Try to get a command
+        // Holding the lock at this point
+        while (!TAILQ_EMPTY(&gdev->command_queue)) {
+            gcmd = TAILQ_FIRST(&gdev->command_queue);
+            TAILQ_REMOVE(&gdev->command_queue, gcmd, next);
+
+            pthread_mutex_unlock(&gdev->queue_mutex);
+
+            // Release the lock and start processing
+            virtio_gpu_simple_process_cmd(gcmd, vdev);
+            // Notify the frontend and free memory after the command is
+            // completed, iov is freed by virtio_gpu_simple_process_cmd
+
+            request_cnt++;
+
+            if (request_cnt >= VIRTIO_GPU_MAX_REQUEST_BEFORE_KICK) {
+                // Processed a certain number of requests, kick the frontend
+                virtio_inject_irq(&vdev->vqs[gcmd->from_queue]);
+                request_cnt = 0;
+                // log_info("%s: processed request >= 16, kick frontend",
+                // __func__);
+            }
+
+            free(gcmd);
+
+            // Since we are still in the processing loop, no need to worry about
+            // losing awake
+            // Re-acquire the lock on the next check
+            pthread_mutex_lock(&gdev->queue_mutex);
+        }
+
+        if (request_cnt != 0) {
+            // Processed requests but the task queue is empty, immediately kick
+            // the frontend
+            virtio_inject_irq(&vdev->vqs[gcmd->from_queue]);
+            request_cnt = 0;
+            // log_info("%s: request queue empty, kick frontend", __func__);
+        }
+
+        pthread_cond_wait(&gdev->gpu_cond, &gdev->queue_mutex);
+    }
+}

--- a/tools/virtio_gpu_base.c
+++ b/tools/virtio_gpu_base.c
@@ -1,0 +1,368 @@
+#include "log.h"
+#include "sys/queue.h"
+#include "unistd.h"
+#include "virtio.h"
+#include "virtio_gpu.h"
+#include <fcntl.h>
+#include <pthread.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <xf86drm.h>
+#include <xf86drmMode.h>
+
+GPUDev *init_gpu_dev(GPURequestedState *requested_state) {
+    log_info("initializing GPUDev");
+
+    if (requested_state == NULL) {
+        log_error("null requested state");
+        return NULL;
+    }
+
+    // Allocate memory
+    GPUDev *gdev = malloc(sizeof(GPUDev));
+
+    if (gdev == NULL) {
+        log_error("failed to initialize GPUDev");
+        // Let the calling function free the memory
+        // free(requested_state);
+        return NULL;
+    }
+
+    memset(gdev, 0, sizeof(GPUDev));
+
+    // Initialize config
+    gdev->config.events_read = 0;
+    gdev->config.events_clear = 0;
+    gdev->config.num_scanouts = HVISOR_VIRTIO_GPU_MAX_SCANOUTS;
+    gdev->config.num_capsets = 0;
+
+    // Initialize number of scanouts
+    gdev->scanouts_num = 1;
+
+    // Initialize scanout 0
+    // TODO: Use JSON initialization or read from device
+    gdev->scanouts[0].width = SCANOUT_DEFAULT_WIDTH;
+    gdev->scanouts[0].height = SCANOUT_DEFAULT_HEIGHT;
+
+    log_debug("set scanouts[0] width: %d height: %d", gdev->scanouts[0].width,
+              gdev->scanouts[0].height);
+
+    // gdev->scanouts[0].x = 0;
+    // gdev->scanouts[0].y = 0;
+    // gdev->scanouts[0].resource_id = 0;
+    gdev->scanouts[0].current_cursor = NULL;
+    gdev->scanouts[0].card0_fd = -1;
+    gdev->enabled_scanout_bitmask |= (1 << 0); // Enable scanout 0
+
+    // The framebuffer of the scanout is set by the driver frontend, see
+    // virtio_gpu_set_scanout
+
+    // TODO: Multiple requested_states (need to modify JSON parsing)
+    gdev->requested_states[0].width = requested_state->width;
+    gdev->requested_states[0].height = requested_state->height;
+
+    log_debug("requested state from json, width: %d height: %d",
+              gdev->requested_states[0].width,
+              gdev->requested_states[0].height);
+
+    // Initialize resource list and command queue
+    TAILQ_INIT(&gdev->resource_list);
+    TAILQ_INIT(&gdev->command_queue);
+
+    // Initialize memory count
+    gdev->hostmem = 0;
+
+    // Initialize async part
+    gdev->close = false;
+
+    return gdev;
+}
+
+int virtio_gpu_init(VirtIODevice *vdev) {
+    log_info("entering %s", __func__);
+
+    // TODO: Display device initialization
+    GPUDev *gdev = vdev->dev;
+
+    // Set the close function for virtio gpu
+    vdev->virtio_close = virtio_gpu_close;
+
+    int drm_fd = 0;
+
+    // Open card0
+    drm_fd = open("/dev/dri/card0", O_RDWR | O_CLOEXEC);
+    if (drm_fd < 0) {
+        log_error("%s failed to open /dev/dri/card0", __func__);
+        return -1;
+    }
+
+    // Get drm resources
+    // Need to get the connector, CRTC, encoder, framebuffer of the device
+    drmModeRes *res = drmModeGetResources(drm_fd);
+    if (!res) {
+        log_error("%s cannot get card0 resource", __func__);
+        close(drm_fd);
+        return -1;
+    }
+
+    // Get connector
+    drmModeConnector *connector = NULL;
+    for (int i = 0; i < res->count_connectors; ++i) {
+        connector = drmModeGetConnector(drm_fd, res->connectors[i]);
+        if (connector->connection == DRM_MODE_CONNECTED) {
+            break;
+        }
+        drmModeFreeConnector(connector);
+    }
+
+    if (!connector || connector->connection != DRM_MODE_CONNECTED) {
+        log_error("%s cannot find a connector", __func__);
+        drmModeFreeResources(res);
+        close(drm_fd);
+        return -1;
+    }
+
+    // Get encoder
+    drmModeEncoder *encoder = drmModeGetEncoder(drm_fd, connector->encoder_id);
+    if (!encoder) {
+        log_error("%s cannot get encoder", __func__);
+        drmModeFreeConnector(connector);
+        drmModeFreeResources(res);
+        close(drm_fd);
+        return -1;
+    }
+
+    // Get CRTC
+    drmModeCrtc *crtc = drmModeGetCrtc(drm_fd, encoder->crtc_id);
+    if (!crtc) {
+        log_error("%s cannot get CRTC", __func__);
+        drmModeFreeEncoder(encoder);
+        drmModeFreeConnector(connector);
+        drmModeFreeResources(res);
+        close(drm_fd);
+        return -1;
+    }
+    // drmModeModeInfo mode = connector->modes[0];
+
+    gdev->scanouts[0].card0_fd = drm_fd;
+    gdev->scanouts[0].crtc = crtc;
+    gdev->scanouts[0].connector = connector;
+    gdev->scanouts[0].encoder = encoder;
+
+    ///
+    log_debug("%s set scanout[0] card0_fd %d", __func__, drm_fd);
+    log_debug("%s set scanout[0] crtc %x with id %d", __func__, crtc,
+              crtc->crtc_id);
+    log_debug("%s set scanout[0] connector %x with id %d", __func__, connector,
+              connector->connector_id);
+    log_debug("%s get scanout[0] connector mode hdisplay: %d, vdisplay: %d",
+              __func__, connector->modes[0].hdisplay,
+              connector->modes[0].vdisplay);
+    log_debug("%s set scanout[0] encoder %x", __func__, encoder);
+    ///
+
+    gdev->scanouts[0].width = connector->modes[0].hdisplay;
+    gdev->scanouts[0].height = connector->modes[0].vdisplay;
+
+    // async
+    pthread_create(&gdev->gpu_thread, NULL, virtio_gpu_handler, vdev);
+    pthread_cond_init(&gdev->gpu_cond, NULL);
+    pthread_mutex_init(&gdev->queue_mutex, NULL);
+
+    return 0;
+}
+
+void virtio_gpu_close(VirtIODevice *vdev) {
+    log_info("virtio_gpu close");
+
+    // Reclaim memory related to scanouts
+    GPUDev *gdev = (GPUDev *)vdev->dev;
+    for (int i = 0; i < gdev->scanouts_num; ++i) {
+        free(gdev->scanouts[i].current_cursor);
+
+        virtio_gpu_remove_drm_framebuffer(&gdev->scanouts[i]);
+
+        drmModeFreeCrtc(gdev->scanouts[i].crtc);
+        drmModeFreeEncoder(gdev->scanouts[i].encoder);
+        drmModeFreeConnector(gdev->scanouts[i].connector);
+
+        // Release card0_fd
+        if (gdev->scanouts[i].card0_fd != -1) {
+            close(gdev->scanouts[i].card0_fd);
+        }
+    }
+
+    // Reclaim memory related to resources
+    while (!TAILQ_EMPTY(&gdev->resource_list)) {
+        GPUSimpleResource *temp = TAILQ_FIRST(&gdev->resource_list);
+        TAILQ_REMOVE(&gdev->resource_list, temp, next);
+        free(temp);
+    }
+
+    // Reclaim memory related to command queue
+    while (!TAILQ_EMPTY(&gdev->command_queue)) {
+        GPUCommand *temp = TAILQ_FIRST(&gdev->command_queue);
+        TAILQ_REMOVE(&gdev->command_queue, temp, next);
+        free(temp);
+    }
+
+    // Reclaim async part
+    gdev->close = true;
+    pthread_cond_signal(&gdev->gpu_cond);
+    pthread_join(gdev->gpu_thread, NULL);
+    pthread_cond_destroy(&gdev->gpu_cond);
+    pthread_mutex_destroy(&gdev->queue_mutex);
+
+    free(gdev);
+    gdev = NULL;
+
+    // vq is managed by the driver frontend, free it directly here
+    free(vdev->vqs);
+    free(vdev);
+}
+
+void virtio_gpu_reset(GPUDev *gdev) {
+    // TODO:
+    for (int i = 0; i < HVISOR_VIRTIO_GPU_MAX_SCANOUTS; ++i) {
+        gdev->scanouts[i].resource_id = 0;
+        gdev->scanouts[i].width = 0;
+        gdev->scanouts[i].height = 0;
+        gdev->scanouts[i].x = 0;
+        gdev->scanouts[i].y = 0;
+    }
+}
+
+int virtio_gpu_ctrl_notify_handler(VirtIODevice *vdev, VirtQueue *vq) {
+    log_debug("entering %s", __func__);
+
+    GPUDev *gdev = vdev->dev;
+    uint32_t cnt = 0;
+
+    virtqueue_disable_notify(vq);
+    while (!virtqueue_is_empty(vq)) {
+        int err = virtio_gpu_handle_single_request(vdev, vq, GPU_CONTROL_QUEUE);
+        if (err < 0) {
+            log_error("notify handle failed at zone %d, device %s",
+                      vdev->zone_id, virtio_device_type_to_string(vdev->type));
+            // return -1;
+        }
+        cnt++;
+    }
+    log_debug("%s add %d request to command queue", __func__, cnt);
+
+    // Kick processing thread
+    pthread_mutex_lock(&gdev->queue_mutex);
+    pthread_cond_signal(&gdev->gpu_cond);
+    pthread_mutex_unlock(&gdev->queue_mutex);
+
+    virtqueue_enable_notify(vq);
+
+    return 0;
+}
+
+int virtio_gpu_cursor_notify_handler(VirtIODevice *vdev, VirtQueue *vq) {
+    log_debug("entering %s", __func__);
+
+    virtqueue_disable_notify(vq);
+    while (!virtqueue_is_empty(vq)) {
+        int err = virtio_gpu_handle_single_request(vdev, vq, GPU_CURSOR_QUEUE);
+        if (err < 0) {
+            log_error("notify handle failed at zone %d, device %s",
+                      vdev->zone_id, virtio_device_type_to_string(vdev->type));
+            // return -1;
+        }
+    }
+    virtqueue_enable_notify(vq);
+
+    virtio_inject_irq(vq);
+
+    return 0;
+}
+
+int virtio_gpu_handle_single_request(VirtIODevice *vdev, VirtQueue *vq,
+                                     uint32_t from) {
+    // virtio-gpu dev
+    GPUDev *gdev = vdev->dev;
+    // Starting index of the descriptor chain
+    uint16_t first_idx_on_chain = 0;
+    // iovec used for communication
+    struct iovec *iov = NULL;
+    // Flags of all descriptors on the descriptor chain
+    uint16_t *flags = NULL;
+    // Number of processed descriptors
+    // The number of descriptors is equal to the number of buffers, which is
+    // also equal to the length of the iov array
+    int desc_processed_num = 0;
+    // Generated command
+    GPUCommand *gcmd = NULL;
+
+    // According to the descriptor chain, gather all buffers for communication
+    // into iov for management
+    desc_processed_num = process_descriptor_chain(vq, &first_idx_on_chain, &iov,
+                                                  &flags, 0, true);
+    if (desc_processed_num < 1) {
+        log_debug("no more desc at %s", __func__);
+        return 0;
+    }
+
+    gcmd = malloc(sizeof(GPUCommand));
+    memset(gcmd, 0, sizeof(GPUCommand));
+    gcmd->resp_iov = iov;
+    gcmd->resp_iov_cnt = desc_processed_num;
+    gcmd->resp_idx = first_idx_on_chain;
+    gcmd->from_queue = from;
+
+    // Add to command queue
+    pthread_mutex_lock(&gdev->queue_mutex);
+    TAILQ_INSERT_TAIL(&gdev->command_queue, gcmd, next);
+    pthread_mutex_unlock(&gdev->queue_mutex);
+
+    free(flags);
+    return 0;
+}
+
+size_t iov_to_buf_full(const struct iovec *iov, unsigned int iov_cnt,
+                       size_t offset, void *buf, size_t bytes_need_copy) {
+    size_t done = 0;
+    unsigned int i = 0;
+    for (; (offset || done < bytes_need_copy) && i < iov_cnt; i++) {
+        if (offset < iov[i].iov_len) {
+            size_t len = MIN(iov[i].iov_len - offset, bytes_need_copy - done);
+            memcpy(buf + done, iov[i].iov_base + offset, len);
+            done += len;
+            offset = 0;
+        } else {
+            offset -= iov[i].iov_len;
+        }
+    }
+    if (offset != 0) {
+        log_error("failed to copy iov to buf");
+        return 0;
+    }
+
+    return done;
+}
+
+size_t buf_to_iov_full(const struct iovec *iov, unsigned int iov_cnt,
+                       size_t offset, const void *buf, size_t bytes_need_copy) {
+    size_t done = 0;
+    unsigned int i = 0;
+    for (; (offset || done < bytes_need_copy) && i < iov_cnt; i++) {
+        if (offset < iov[i].iov_len) {
+            size_t len = MIN(iov[i].iov_len - offset, bytes_need_copy - done);
+            memcpy(iov[i].iov_base + offset, buf + done, len);
+            done += len;
+            offset = 0;
+        } else {
+            offset -= iov[i].iov_len;
+        }
+    }
+    if (offset != 0) {
+        log_error("failed to copy buf to iov");
+        return 0;
+    }
+
+    return done;
+}

--- a/tools/virtio_net.c
+++ b/tools/virtio_net.c
@@ -118,7 +118,7 @@ void virtio_net_event_handler(int fd, int epoll_type, void *param)
         return;
     }
     while (!virtqueue_is_empty(vq)) {
-        n = process_descriptor_chain(vq, &idx, &iov, NULL, 0);
+        n = process_descriptor_chain(vq, &idx, &iov, NULL, 0, false);
         if (n < 1 || n > VIRTQUEUE_NET_MAX_SIZE) {
             log_error("process_descriptor_chain failed");
             goto free_iov;
@@ -164,7 +164,7 @@ static void virtq_tx_handle_one_request(NetDev *net, VirtQueue *vq)
         return;
     }
 
-    n = process_descriptor_chain(vq, &idx, &iov, NULL, 1);
+    n = process_descriptor_chain(vq, &idx, &iov, NULL, 1, false);
     if (n < 1) {
         return ;
 	}


### PR DESCRIPTION
### How to compile
We need libdrm for compile virtio-gpu, considering **arm64** as target platform

```shell
wget https://dri.freedesktop.org/libdrm/libdrm-2.4.100.tar.gz
tar -xzvf libdrm-2.4.100.tar.gz
cd libdrm-2.4.100
```

tips: Versions beyond 2.4.100 will be compiled in a different way, check https://dri.freedesktop.org/libdrm for more versions

```shell
# install to your aarch64-linux-gnu compiler
./configure --host=aarch64-linux-gnu --prefix=/usr/aarch64-linux-gnu && make && make install

# install to `install` folder under libdrm
mkdir install
./configure --host=aarch64-linux-gnu --prefix=/path_to_install/install && make && make install

# notice that `prefix` must be an absolute path
```

To support libdrm in your language server, just link include path to your setting files

And finally, we need to edit `include_dirs` under hvisor-tool/tools/Makefiles

```
include_dirs := -I../include -I./include -I../cJSON/ -I/usr/aarch64-linux-gnu/include -I/usr/aarch64-linux-gnu/include/libdrm -L/usr/aarch64-linux-gnu/lib -ldrm -pthread
```

tips: You should edit it with your own install path

And `cd` to your root path and `make all` should do it
