### PR TITLE
Fix Virtio MMIO Register Names, Enhance Makefile, and Optimize VIRTIO_GPU Format Macros

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ __loongarch*
 .config.old
 .cache
 compile_commands.json
+output/

--- a/Makefile
+++ b/Makefile
@@ -9,34 +9,41 @@ export KDIR
 export ARCH
 export LOG
 export VIRTIO_GPU
-.PHONY: all env tools driver clean
 
-# check if KDIR is set
-ifeq ($(KDIR),)
-$(error Linux kernel directory is not set. Please set environment variable 'KDIR')
-endif
+.PHONY: all env tools driver clean transfer tftp transfer_nxp check-kdir
+
+OUTPUT_DIR ?= output
+TFTP_DIR ?= tftp
 
 all: tools driver
+	mkdir -p $(OUTPUT_DIR)
+	cp driver/hvisor.ko tools/hvisor $(OUTPUT_DIR)
 
 env:
 	git submodule update --init --recursive
 
+check-kdir:
+ifeq ($(KDIR),)
+	$(error Linux kernel directory is not set. Please set environment variable 'KDIR')
+endif
+
 tools: env
 	$(MAKE) -C tools all
 
-driver: env
+driver: env check-kdir
 	$(MAKE) -C driver all
 
 transfer: all
 	./trans_file.sh ./tools/hvisor 
 	./trans_file.sh ./driver/hvisor.ko 
 
-# transfer_nxp: all
-# 	sudo mount $(DEV) /mnt/
-# 	sudo rm -f /mnt/home/arm64/hvisor /mnt/home/arm64/hvisor.ko
-# 	sudo cp ./tools/hvisor /mnt/home/arm64
-# 	sudo cp ./driver/hvisor.ko /mnt/home/arm64
-# 	sudo umount $(DEV)
+tftp:
+	@mkdir -p $(OUTPUT_DIR)
+	@if [ -n "$(wildcard $(OUTPUT_DIR)/*)" ]; then \
+		cp $(OUTPUT_DIR)/* $(TFTP_DIR); \
+	else \
+		echo "No files found in $(OUTPUT_DIR), skipping copy."; \
+	fi
 
 transfer_nxp: all
 	sudo cp ./tools/hvisor ~/tftp
@@ -45,6 +52,6 @@ transfer_nxp: all
 	sudo cp ./driver/hvisor.ko ~/tftp
 	sudo cp ./driver/ivc.ko ~/tftp
 
-clean:
+clean: check-kdir
 	make -C tools clean
 	make -C driver clean

--- a/tools/virtio.c
+++ b/tools/virtio.c
@@ -577,18 +577,6 @@ static const char *virtio_mmio_reg_name(uint64_t offset) {
         return "VIRTIO_MMIO_QUEUE_USED_LOW";
     case VIRTIO_MMIO_QUEUE_USED_HIGH:
         return "VIRTIO_MMIO_QUEUE_USED_HIGH";
-#ifndef RISCV64
-    case VIRTIO_MMIO_SHM_SEL:
-        return "VIRTIO_MMIO_SHM_SEL";
-    case VIRTIO_MMIO_SHM_LEN_LOW:
-        return "VIRTIO_MMIO_SHM_LEN_LOW";
-    case VIRTIO_MMIO_SHM_LEN_HIGH:
-        return "VIRTIO_MMIO_SHM_LEN_HIGH";
-    case VIRTIO_MMIO_SHM_BASE_LOW:
-        return "VIRTIO_MMIO_SHM_BASE_LOW";
-    case VIRTIO_MMIO_SHM_BASE_HIGH:
-#endif
-        return "VIRTIO_MMIO_SHM_BASE_HIGH";
     case VIRTIO_MMIO_CONFIG_GENERATION:
         return "VIRTIO_MMIO_CONFIG_GENERATION";
     case VIRTIO_MMIO_CONFIG:


### PR DESCRIPTION
1. Fix the issue of missing register names in virtio_mmio_reg_name
2. Add output and tftp options to the Makefile
3. Remove dependency on KDIR for most targets, keeping it only for driver and clean
