### PR TITLE
support for rk3568 and code fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ All operations should be performed in the `hvisor-tool` directory on an x86 host
 * Compile the command-line tools and kernel modules
 
 ```bash
-make all ARCH=<arch> LOG=<log> KDIR=/path/to/your-linux VIRTIO_GPU=[y/n]
+make all ARCH=<arch> LOG=<log> KDIR=/path/to/your-linux VIRTIO_GPU=[y/n] ROOT=/path/to/target_rootfs
 ```
 
 Where `<arch>` should be either `arm64` or `riscv`.

--- a/driver/hvisor.c
+++ b/driver/hvisor.c
@@ -17,6 +17,8 @@
 #include <linux/sched/signal.h>
 #include <linux/string.h>
 #include <linux/vmalloc.h>
+#include <linux/uaccess.h>
+#include <linux/version.h>
 
 struct virtio_bridge *virtio_bridge;
 int virtio_irq = -1;
@@ -104,27 +106,27 @@ static int hvisor_zone_start(zone_config_t __user *arg) {
     return err;
 }
 
-#ifndef LOONGARCH64
-static int is_reserved_memory(unsigned long phys, unsigned long size) {
-    struct device_node *parent, *child;
-    struct reserved_mem *rmem;
-    phys_addr_t mem_base;
-    size_t mem_size;
-    int count = 0;
-    parent = of_find_node_by_path("/reserved-memory");
-    count = of_get_child_count(parent);
+// #ifndef LOONGARCH64
+// static int is_reserved_memory(unsigned long phys, unsigned long size) {
+//     struct device_node *parent, *child;
+//     struct reserved_mem *rmem;
+//     phys_addr_t mem_base;
+//     size_t mem_size;
+//     int count = 0;
+//     parent = of_find_node_by_path("/reserved-memory");
+//     count = of_get_child_count(parent);
 
-    for_each_child_of_node(parent, child) {
-        rmem = of_reserved_mem_lookup(child);
-        mem_base = rmem->base;
-        mem_size = rmem->size;
-        if (mem_base <= phys && (mem_base + mem_size) >= (phys + size)) {
-            return 1;
-        }
-    }
-    return 0;
-}
-#endif
+//     for_each_child_of_node(parent, child) {
+//         rmem = of_reserved_mem_lookup(child);
+//         mem_base = rmem->base;
+//         mem_size = rmem->size;
+//         if (mem_base <= phys && (mem_base + mem_size) >= (phys + size)) {
+//             return 1;
+//         }
+//     }
+//     return 0;
+// }
+// #endif
 
 static int hvisor_zone_list(zone_list_args_t __user *arg) {
     int ret;
@@ -246,9 +248,15 @@ static irqreturn_t virtio_irq_handler(int irq, void *dev_id) {
     // Send signal SIGHVI to hvisor user task
     if (task != NULL) {
         // pr_info("send signal to hvisor device\n");
+#if (LINUX_VERSION_CODE <= KERNEL_VERSION(4, 20, 0))
+        if (send_sig_info(SIGHVI, (struct siginfo *)&info, task) < 0) {
+            pr_err("Unable to send signal\n");
+        }
+#else
         if (send_sig_info(SIGHVI, (struct kernel_siginfo *)&info, task) < 0) {
             pr_err("Unable to send signal\n");
         }
+#endif
     }
     return IRQ_HANDLED;
 }

--- a/driver/ivc_driver.c
+++ b/driver/ivc_driver.c
@@ -53,7 +53,7 @@ static struct class *ivc_class;
 extern u8 __dtb_hivc_template_begin[], __dtb_hivc_template_end[];
 
 static int hvisor_ivc_info(void) {
-    int err = 0, i;
+    int err = 0;
     if (ivc_info == NULL)
         ivc_info = kmalloc(sizeof(ivc_info_t), GFP_KERNEL);
     err = hvisor_call(HVISOR_HC_IVC_INFO, __pa(ivc_info), sizeof(ivc_info_t));
@@ -61,7 +61,6 @@ static int hvisor_ivc_info(void) {
 }
 
 static int ivc_open(struct inode *inode, struct file *file) {
-    int err;
     struct ivc_dev *dev = container_of(inode->i_cdev, struct ivc_dev, cdev);
     dev->task = get_current();
     file->private_data = dev;
@@ -69,7 +68,7 @@ static int ivc_open(struct inode *inode, struct file *file) {
 }
 
 static int hvisor_user_ivc_info(ivc_uinfo_t __user *uinfo) {
-    int err = 0, i;
+    int i;
     uinfo->len = ivc_info->len;
     for (i = 0; i < ivc_info->len; i++) {
         uinfo->ivc_ids[i] = ivc_info->ivc_ids[i];
@@ -93,7 +92,7 @@ static long ivc_ioctl(struct file *file, unsigned int ioctl,
 
 static int ivc_map(struct file *filp, struct vm_area_struct *vma) {
     unsigned long long phys, offset;
-    int i, err = 0, is_control_table = 0, idx;
+    int err = 0, idx;
     size_t size = vma->vm_end - vma->vm_start;
     struct ivc_dev *dev = filp->private_data;
     idx = dev->idx;
@@ -157,14 +156,14 @@ static irqreturn_t ivc_irq_handler(int irq, void *dev_id) {
     return IRQ_HANDLED;
 }
 
-static struct property *alloc_property(const char *name, int len) {
-    struct property *prop;
-    prop = kzalloc(sizeof(struct property), GFP_KERNEL);
-    prop->name = kstrdup(name, GFP_KERNEL);
-    prop->length = len;
-    prop->value = kzalloc(len, GFP_KERNEL);
-    return prop;
-}
+// static struct property *alloc_property(const char *name, int len) {
+//     struct property *prop;
+//     prop = kzalloc(sizeof(struct property), GFP_KERNEL);
+//     prop->name = kstrdup(name, GFP_KERNEL);
+//     prop->length = len;
+//     prop->value = kzalloc(len, GFP_KERNEL);
+//     return prop;
+// }
 
 // static int add_ivc_device_node(void)
 // {

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -3,10 +3,11 @@ objects ?= $(sources:.c=.o)
 ivc_demo_object ?= ivc_demo.o
 rpmsg_demo_object ?= rpmsg_demo.o
 hvisor_objects ?= $(filter-out $(ivc_demo_object) $(rpmsg_demo_object), $(objects))
+ROOT ?= /
 
-CFLAGS := -Wall -Wextra -DLOG_USE_COLOR -DHLOG=$(LOG)
-include_dirs := -I../include -I./include -I../cJSON/ -pthread
-
+CFLAGS := -Wall -Wextra -DLOG_USE_COLOR -DHLOG=$(LOG) --sysroot=$(ROOT)
+include_dirs := -I../include -I./include -I../cJSON/ -l:libpthread.so.0
+LIBS := -L$(ROOT)/usr/lib/aarch64-linux-gnu -L$(ROOT)/lib/
 ifeq ($(VIRTIO_GPU), y)
 	sources += $(wildcard ./virtio_gpu/*.c)
 	CFLAGS += -DENABLE_VIRTIO_GPU
@@ -54,16 +55,16 @@ all: hvisor ivc_demo rpmsg_demo
 	rm -f $@.$$$$
 
 $(objects): %.o: %.c
-	$(CC) $(CFLAGS) $(include_dirs) -c -o $@ $<
+	$(CC) $(CFLAGS) $(include_dirs) $(LIBS) -c -o $@ $<
 
 hvisor: $(hvisor_objects)
-	$(CC) -o $@ $^ $(include_dirs)
+	$(CC) -o $@ $^ $(CFLAGS) $(include_dirs) $(LIBS)
 
 ivc_demo: $(ivc_demo_object)
-	$(CC) -o $@ $^ $(include_dirs)
+	$(CC) -o $@ $^ $(CFLAGS) $(include_dirs) $(LIBS)
 
 rpmsg_demo: $(rpmsg_demo_object)
-	$(CC) -o $@ $^ $(include_dirs)
+	$(CC) -o $@ $^ $(CFLAGS) $(include_dirs) $(LIBS)
 
 clean:
 	rm -f hvisor ivc_demo *.o *.d *.d.* 


### PR DESCRIPTION
1.added support for Linux kernel versions below 4.20
2.removed some unused code
3.added the ROOT parameter to handle the discrepancy between the board's library environment and the cross-compilation environment