### PR TITLE
add dynamic header size based on driver features in virtio-net

### DIFF
--- a/driver/hvisor.c
+++ b/driver/hvisor.c
@@ -91,19 +91,21 @@ static int hvisor_finish_req(void) {
 //     vma = get_vm_area(size, VM_IOREMAP);
 //     if (!vma)
 //     {
-//         pr_err("hvisor.ko: failed to allocate virtual kernel memory for image\n"); 
-//         return -ENOMEM;
+//         pr_err("hvisor.ko: failed to allocate virtual kernel memory for
+//         image\n"); return -ENOMEM;
 //     }
 //     vma->phys_addr = phys_start;
 
-//     if (ioremap_page_range((unsigned long)vma->addr, (unsigned long)(vma->addr + size), phys_start, PAGE_KERNEL_EXEC))
+//     if (ioremap_page_range((unsigned long)vma->addr, (unsigned
+//     long)(vma->addr + size), phys_start, PAGE_KERNEL_EXEC))
 //     {
 //         pr_err("hvisor.ko: failed to ioremap image\n");
 //         err = -EFAULT;
 //         goto unmap_vma;
 //     }
 //     // flush icache will also flush dcache
-//     flush_icache_range((unsigned long)(vma->addr), (unsigned long)(vma->addr + size));
+//     flush_icache_range((unsigned long)(vma->addr), (unsigned long)(vma->addr
+//     + size));
 
 // unmap_vma:
 //     vunmap(vma->addr);

--- a/tools/hvisor.c
+++ b/tools/hvisor.c
@@ -95,18 +95,6 @@ int open_dev() {
     return fd;
 }
 
-// static void get_info(char *optarg, char **path, u64 *address) {
-// 	char *now;
-// 	*path = strtok(optarg, ",");
-// 	now = strtok(NULL, "=");
-// 	if (strcmp(now, "addr") == 0) {
-// 		now = strtok(NULL, "=");
-// 		*address = strtoull(now, NULL, 16);
-// 	} else {
-// 		help(1);
-// 	}
-// }
-
 static __u64 load_image_to_memory(const char *path, __u64 load_paddr) {
     if (strcmp(path, "null") == 0) {
         return 0;

--- a/tools/include/virtio_net.h
+++ b/tools/include/virtio_net.h
@@ -30,7 +30,7 @@
 
 typedef struct virtio_net_config NetConfig;
 typedef struct virtio_net_hdr_v1 NetHdr;
-
+typedef struct virtio_net_hdr NetHdrLegacy;
 typedef struct virtio_net_dev {
     NetConfig config;
     int tapfd;

--- a/tools/ivc_demo.c
+++ b/tools/ivc_demo.c
@@ -34,10 +34,9 @@ static int open_dev() {
 
 int main(int argc, char *argv[]) {
     printf("ivc_demo: starting\n");
-    int fd, err, sig, ivc_id, is_send = 0, ret;
-    ivc_uinfo_t ivc_info;
-    void *tb_virt, *mem_virt;
-    unsigned long long ct_ipa, offset;
+    int fd, is_send = 0, ret;
+    void *tb_virt;
+    unsigned long long offset;
 
     if (argc != 2) {
         printf("Usage: ivc_demo send|receive\n");

--- a/tools/rpmsg_demo.c
+++ b/tools/rpmsg_demo.c
@@ -59,7 +59,8 @@ static int rpmsg_create_eptdev(char *eptdev_name, int local_port,
 }
 
 static int rpmsg_open_eptdev(char *eptdev_name, int flags) {
-    int efd, endpt;
+    (void)eptdev_name;
+    int efd;
 
     efd = open("/dev/rpmsg0", O_RDWR | flags);
     if (efd < 0) {
@@ -112,7 +113,7 @@ static int rpmsg_destroy_eptdev(int fd) {
     close(fd);
     return 0;
 }
-int main(int argc, char const *argv[]) {
+int main() {
     int ret, packet_len;
     char packet_buf[512] = {0};
     printf("rpmsg_demo start\n");

--- a/tools/virtio_net.c
+++ b/tools/virtio_net.c
@@ -95,16 +95,27 @@ static inline struct iovec *rm_iov_header(struct iovec *iov, int *niov,
     }
 }
 
+size_t get_nethdr_size(VirtIODevice *vdev) {
+    // Virtio 1.0 specifies the header as NetHdr. But the legacy version
+    // specifies the headr as NetHdrLegacy
+    if (vdev->regs.drv_feature & VIRTIO_F_VERSION_1) {
+        return sizeof(NetHdr);
+    } else {
+        return sizeof(NetHdrLegacy);
+    }
+}
+
 /// Called when tap device received packets
 void virtio_net_event_handler(int fd, int epoll_type, void *param) {
     log_debug("virtio_net_event_handler");
     VirtIODevice *vdev = param;
-    NetHdr *vnet_header;
+    void *vnet_header;
     struct iovec *iov, *iov_packet;
     NetDev *net = vdev->dev;
     VirtQueue *vq = &vdev->vqs[NET_QUEUE_RX];
     int n, len;
     uint16_t idx;
+    size_t header_len = get_nethdr_size(vdev);
     if (fd != net->tapfd || epoll_type != EPOLLIN) {
         log_error("invalid event");
         return;
@@ -132,7 +143,7 @@ void virtio_net_event_handler(int fd, int epoll_type, void *param) {
             goto free_iov;
         }
         vnet_header = iov[0].iov_base;
-        iov_packet = rm_iov_header(iov, &n, sizeof(NetHdr));
+        iov_packet = rm_iov_header(iov, &n, header_len);
         if (iov_packet == NULL)
             goto free_iov;
         // Read a packet from tap device
@@ -146,10 +157,12 @@ void virtio_net_event_handler(int fd, int epoll_type, void *param) {
             break;
         }
 
-        memset(vnet_header, 0, sizeof(NetHdr));
-        vnet_header->num_buffers = 1;
+        memset(vnet_header, 0, header_len);
+        if (vdev->regs.drv_feature & VIRTIO_F_VERSION_1) {
+            ((NetHdr *)vnet_header)->num_buffers = 1;
+        }
 
-        update_used_ring(vq, idx, len + sizeof(NetHdr));
+        update_used_ring(vq, idx, len + header_len);
         free(iov);
     }
 
@@ -159,13 +172,15 @@ free_iov:
     free(iov);
 }
 
-static void virtq_tx_handle_one_request(NetDev *net, VirtQueue *vq) {
+static void virtq_tx_handle_one_request(VirtIODevice *vdev, VirtQueue *vq) {
     struct iovec *iov = NULL;
     int i, n;
     int packet_len, all_len; // all_len include the header length.
     uint16_t idx;
     static char pad[64];
     ssize_t len;
+    NetDev *net = vdev->dev;
+    size_t header_len = get_nethdr_size(vdev);
     if (net->tapfd == -1) {
         log_error("tap device is invalid");
         return;
@@ -179,9 +194,9 @@ static void virtq_tx_handle_one_request(NetDev *net, VirtQueue *vq) {
     for (i = 0, all_len = 0; i < n; i++)
         all_len += iov[i].iov_len;
 
-    packet_len = all_len - sizeof(NetHdr);
-    iov[0].iov_base += sizeof(NetHdr);
-    iov[0].iov_len -= sizeof(NetHdr);
+    packet_len = all_len - header_len;
+    iov[0].iov_base += header_len;
+    iov[0].iov_len -= header_len;
     log_debug("packet send: %d bytes", packet_len);
 
     // The mininum packet for data link layer is 64 bytes.
@@ -202,7 +217,7 @@ int virtio_net_txq_notify_handler(VirtIODevice *vdev, VirtQueue *vq) {
     log_debug("virtio_net_txq_notify_handler");
     virtqueue_disable_notify(vq);
     while (!virtqueue_is_empty(vq)) {
-        virtq_tx_handle_one_request(vdev->dev, vq);
+        virtq_tx_handle_one_request(vdev, vq);
     }
     virtqueue_enable_notify(vq);
     // TODO: Can we don't inject irq when send packets to improve performance?

--- a/tools/virtio_net.c
+++ b/tools/virtio_net.c
@@ -98,7 +98,7 @@ static inline struct iovec *rm_iov_header(struct iovec *iov, int *niov,
 size_t get_nethdr_size(VirtIODevice *vdev) {
     // Virtio 1.0 specifies the header as NetHdr. But the legacy version
     // specifies the headr as NetHdrLegacy
-    if (vdev->regs.drv_feature & VIRTIO_F_VERSION_1) {
+    if (vdev->regs.drv_feature & (1ULL << VIRTIO_F_VERSION_1)) {
         return sizeof(NetHdr);
     } else {
         return sizeof(NetHdrLegacy);
@@ -158,7 +158,7 @@ void virtio_net_event_handler(int fd, int epoll_type, void *param) {
         }
 
         memset(vnet_header, 0, header_len);
-        if (vdev->regs.drv_feature & VIRTIO_F_VERSION_1) {
+        if (vdev->regs.drv_feature & (1ULL << VIRTIO_F_VERSION_1)) {
             ((NetHdr *)vnet_header)->num_buffers = 1;
         }
 


### PR DESCRIPTION
In linux virtio-net driver, it supports the feature VIRTIO_F_VERSION_1. This makes the virtio-net header as virtio_net_hdr_v1. However, in ruxos virtio-net driver, it doesn't support VIRTIO_F_VERSION_1. So ruxos's virtio-net header should be virtio_net_hdr. Both virtio_net_hdr_v1 and virtio_net_hdr are defined at include/linux/virtio_net.h, and they are different in size. So I add the check for feature and make hvisor-tool deal with this difference correctly.