### PR TITLE
chore(irq): sync with hvisor, raise interrupt limit to 1024

### DIFF
--- a/include/zone_config.h
+++ b/include/zone_config.h
@@ -18,7 +18,11 @@
 #define MEM_TYPE_VIRTIO 2
 
 #define CONFIG_MAX_MEMORY_REGIONS 64
-#define CONFIG_MAX_INTERRUPTS 32
+
+typedef __u32 BitmapWord;
+#define CONFIG_MAX_INTERRUPTS 1024
+#define CONFIG_INTERRUPTS_BITMAP_BITS_PER_WORD 32
+
 #define CONFIG_MAX_ZONES 32
 #define CONFIG_NAME_MAXLEN 32
 #define CONFIG_MAX_PCI_DEV 32
@@ -123,7 +127,7 @@ struct ivc_config {
 };
 typedef struct ivc_config ivc_config_t;
 
-#define CONFIG_MAGIC_VERSION 0x03
+#define CONFIG_MAGIC_VERSION 0x04
 
 // Every time you change the struct, you should also change the
 // `CONFIG_MAGIC_VERSION`
@@ -132,8 +136,8 @@ struct zone_config {
     __u64 cpus;
     __u32 num_memory_regions;
     memory_region_t memory_regions[CONFIG_MAX_MEMORY_REGIONS];
-    __u32 num_interrupts;
-    __u32 interrupts[CONFIG_MAX_INTERRUPTS];
+    BitmapWord interrupts_bitmap[CONFIG_MAX_INTERRUPTS /
+                                 CONFIG_INTERRUPTS_BITMAP_BITS_PER_WORD];
     __u32 num_ivc_configs;
     ivc_config_t ivc_configs[CONFIG_MAX_IVC_CONFIGS];
 

--- a/tools/hvisor.c
+++ b/tools/hvisor.c
@@ -466,10 +466,16 @@ static int zone_start_from_json(const char *json_config_path,
                   mem_region->virtual_start, mem_region->size);
     }
 
-    config->num_interrupts = num_interrupts;
+    // irq
+    memset(config->interrupts_bitmap, 0,
+           sizeof(BitmapWord) * (CONFIG_MAX_INTERRUPTS /
+                                 CONFIG_INTERRUPTS_BITMAP_BITS_PER_WORD));
     for (int i = 0; i < num_interrupts; i++) {
-        config->interrupts[i] =
-            SAFE_CJSON_GET_ARRAY_ITEM(interrupts_json, i)->valueint;
+        __u32 irq = SAFE_CJSON_GET_ARRAY_ITEM(interrupts_json, i)->valueint;
+
+        size_t word_index = irq / CONFIG_INTERRUPTS_BITMAP_BITS_PER_WORD;
+        size_t bit_index = irq % CONFIG_INTERRUPTS_BITMAP_BITS_PER_WORD;
+        config->interrupts_bitmap[word_index] |= ((BitmapWord)1) << bit_index;
     }
 
     // ivc


### PR DESCRIPTION
This is a necessary synchronization step to match the increased interrupt limit in the hvisor repository. The core hypervisor was updated to support a larger number of interrupts for modern SoCs, and this tool must use the same value to ensure compatibility when configuring zones.

Refs: syswonder/hvisor#213
