### PR TITLE
fix(Makefile): update CFLAGS and LDFLAGS for static linking

### DIFF
--- a/tools/Makefile
+++ b/tools/Makefile
@@ -45,7 +45,7 @@ ifeq ($(LIBC), musl)
 include_dirs += -I./compat/
 endif
 
-LDFLAGS := -pthread -static
+LDFLAGS := -lpthread -static
 
 # LIBS := -L$(ROOT)/usr/lib/$(toolchain) -L$(ROOT)/lib
 # LIBS := -L/opt/aarch64-linux-musl-cross/aarch64-linux-musl -L/opt/aarch64-linux-musl-cross/lib


### PR DESCRIPTION
This pull request updates the `CFLAGS` and `LDFLAGS` in the Makefile to enable static linking. This ensures that the generated binary does not depend on shared libraries at runtime.

Closes: #60 