### PR TITLE
solve virtio_inject_irq's concurrency issue

### DIFF
--- a/tools/virtio.c
+++ b/tools/virtio.c
@@ -920,15 +920,15 @@ void virtio_inject_irq(VirtQueue *vq) {
     volatile struct device_res *res;
 
     // virtio_bridge is a global resource located in shared memory.
-    // Access to critical resources such as res_front and res_rear requires locking.
+    // Access to critical resources such as res_front and res_rear requires
+    // locking.
 
     // Since the shared resources related to res_list are only accessed
     //  at one specific code location, a lock before polling is_queue_full
     //  is enough to ensure thread safety and performance.
     pthread_mutex_lock(&RES_MUTEX);
 
-    while (is_queue_full(virtio_bridge->res_front,
-                         virtio_bridge->res_rear,
+    while (is_queue_full(virtio_bridge->res_front, virtio_bridge->res_rear,
                          MAX_REQ)) {
     }
     unsigned int res_rear = virtio_bridge->res_rear;


### PR DESCRIPTION
Related to #68.

```c
void virtio_inject_irq(VirtQueue *vq) {
    ......
    pthread_mutex_lock(&RES_MUTEX);
    while (is_queue_full(virtio_bridge->res_front,
                         virtio_bridge->res_rear,
                         MAX_REQ)) {
    }
    ......
    pthread_mutex_unlock(&RES_MUTEX);
    ......
}
```

When multiple threads arrive simultaneously, the thread that acquires the lock is given priority.

It continuously polls `is_queue_full` rather than having multiple threads fairly contend for the lock continuously.

This logic is sound here.

Given that access to the critical section is exclusive to this location, it is acceptable for the lock to be held for long durations.