### PR TITLE
build: improve hvisor-tool cross-build compatibility and ivc kernel A…

### DIFF
--- a/driver/ivc_driver.c
+++ b/driver/ivc_driver.c
@@ -25,6 +25,7 @@
 #include <linux/slab.h>
 #include <linux/types.h>
 #include <linux/uaccess.h>
+#include <linux/version.h>
 #include <linux/wait.h>
 
 #include "hvisor.h"
@@ -216,7 +217,13 @@ static int __init ivc_init(void) {
         goto err1;
     pr_info("ivc get major id: %d\n", MAJOR(mdev_id));
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 4, 0)
+    // Linux 6.4+
+    ivc_class = class_create("hivc");
+#else
+    // old interface
     ivc_class = class_create(THIS_MODULE, "hivc");
+#endif
     if (IS_ERR(ivc_class)) {
         err = PTR_ERR(ivc_class);
         goto err1;

--- a/driver/ivc_driver.c
+++ b/driver/ivc_driver.c
@@ -25,6 +25,7 @@
 #include <linux/slab.h>
 #include <linux/types.h>
 #include <linux/uaccess.h>
+#include <linux/version.h>
 #include <linux/wait.h>
 
 #include "hvisor.h"
@@ -216,7 +217,13 @@ static int __init ivc_init(void) {
         goto err1;
     pr_info("ivc get major id: %d\n", MAJOR(mdev_id));
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 4, 0)
+    // Linux 6.4+: class_create(name) - kernel commit 1aaba11da9aa
+    ivc_class = class_create("hivc");
+#else
+    // older: class_create(THIS_MODULE, name)
     ivc_class = class_create(THIS_MODULE, "hivc");
+#endif
     if (IS_ERR(ivc_class)) {
         err = PTR_ERR(ivc_class);
         goto err1;

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -10,6 +10,7 @@ objects ?= $(sources:.c=.o)
 ivc_demo_object ?= ivc_demo.o
 rpmsg_demo_object ?= rpmsg_demo.o
 hvisor_objects ?= $(filter-out $(ivc_demo_object) $(rpmsg_demo_object), $(objects))
+BUILD_DEMOS ?= n
 ROOT ?=
 # gnu or musl
 LIBC ?= gnu
@@ -60,7 +61,9 @@ else
 	CFLAGS += -O2
 endif
 
+ifeq ($(origin CC), default)
 CC := $(CROSS_COMPILE)gcc
+endif
 
 ifeq ($(ARCH), arm64)
 	ifeq ($(VIRTIO_GPU), y)
@@ -76,9 +79,14 @@ else ifeq ($(ARCH), loongarch)
 	endif
 endif
 
+
+ifeq ($(BUILD_DEMOS),y)
+demo_targets := ivc_demo rpmsg_demo
+endif
+
 .PHONY: all clean
 
-all: hvisor ivc_demo rpmsg_demo
+all: hvisor $(demo_targets)
 
 %.d: %.c
 	@set -e; rm -f $@; \

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -11,6 +11,7 @@ objects ?= $(sources:.c=.o)
 ivc_demo_object ?= ivc_demo.o
 rpmsg_demo_object ?= rpmsg_demo.o
 hvisor_objects ?= $(filter-out $(ivc_demo_object) $(rpmsg_demo_object), $(objects))
+BUILD_DEMOS ?= n
 ROOT ?=
 # gnu or musl
 LIBC ?= gnu
@@ -57,8 +58,6 @@ ifeq ($(VIRTIO_SCMI), y)
 	CFLAGS += -DENABLE_VIRTIO_SCMI
 endif
 
-
-
 include $(sources:.c=.d)
 
 ifeq ($(DEBUG), y)
@@ -67,7 +66,9 @@ else
 	CFLAGS += -O2
 endif
 
+ifeq ($(origin CC), default)
 CC := $(CROSS_COMPILE)gcc
+endif
 
 ifeq ($(ARCH), arm64)
 	ifeq ($(VIRTIO_GPU), y)
@@ -83,9 +84,13 @@ else ifeq ($(ARCH), loongarch)
 	endif
 endif
 
+ifeq ($(BUILD_DEMOS),y)
+demo_targets := ivc_demo rpmsg_demo
+endif
+
 .PHONY: all clean
 
-all: hvisor ivc_demo rpmsg_demo
+all: hvisor $(demo_targets)
 
 %.d: %.c
 	@set -e; rm -f $@; \

--- a/tools/include/linux/virtio_mmio.h
+++ b/tools/include/linux/virtio_mmio.h
@@ -1,0 +1,99 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+#ifndef _LINUX_VIRTIO_MMIO_H
+#define _LINUX_VIRTIO_MMIO_H
+
+/* Magic value ("virt" string) - Read Only */
+#define VIRTIO_MMIO_MAGIC_VALUE 0x000
+
+/* Virtio device version - Read Only */
+#define VIRTIO_MMIO_VERSION 0x004
+
+/* Virtio device ID - Read Only */
+#define VIRTIO_MMIO_DEVICE_ID 0x008
+
+/* Virtio vendor ID - Read Only */
+#define VIRTIO_MMIO_VENDOR_ID 0x00c
+
+/* Device features - Read Only */
+#define VIRTIO_MMIO_DEVICE_FEATURES 0x010
+
+/* Device features selector - Write Only */
+#define VIRTIO_MMIO_DEVICE_FEATURES_SEL 0x014
+
+/* Driver features - Write Only */
+#define VIRTIO_MMIO_DRIVER_FEATURES 0x020
+
+/* Driver features selector - Write Only */
+#define VIRTIO_MMIO_DRIVER_FEATURES_SEL 0x024
+
+#ifndef VIRTIO_MMIO_NO_LEGACY
+/* Legacy guest page size - Write Only */
+#define VIRTIO_MMIO_GUEST_PAGE_SIZE 0x028
+#endif
+
+/* Queue selector - Write Only */
+#define VIRTIO_MMIO_QUEUE_SEL 0x030
+
+/* Queue size max - Read Only */
+#define VIRTIO_MMIO_QUEUE_NUM_MAX 0x034
+
+/* Queue size - Write Only */
+#define VIRTIO_MMIO_QUEUE_NUM 0x038
+
+#ifndef VIRTIO_MMIO_NO_LEGACY
+/* Legacy used ring alignment - Write Only */
+#define VIRTIO_MMIO_QUEUE_ALIGN 0x03c
+
+/* Legacy queue PFN - Read Write */
+#define VIRTIO_MMIO_QUEUE_PFN 0x040
+#endif
+
+/* Queue ready - Read Write */
+#define VIRTIO_MMIO_QUEUE_READY 0x044
+
+/* Queue notifier - Write Only */
+#define VIRTIO_MMIO_QUEUE_NOTIFY 0x050
+
+/* Interrupt status - Read Only */
+#define VIRTIO_MMIO_INTERRUPT_STATUS 0x060
+
+/* Interrupt acknowledge - Write Only */
+#define VIRTIO_MMIO_INTERRUPT_ACK 0x064
+
+/* Device status - Read Write */
+#define VIRTIO_MMIO_STATUS 0x070
+
+/* Queue descriptor table address (64-bit split) */
+#define VIRTIO_MMIO_QUEUE_DESC_LOW 0x080
+#define VIRTIO_MMIO_QUEUE_DESC_HIGH 0x084
+
+/* Queue available ring address (64-bit split) */
+#define VIRTIO_MMIO_QUEUE_AVAIL_LOW 0x090
+#define VIRTIO_MMIO_QUEUE_AVAIL_HIGH 0x094
+
+/* Queue used ring address (64-bit split) */
+#define VIRTIO_MMIO_QUEUE_USED_LOW 0x0a0
+#define VIRTIO_MMIO_QUEUE_USED_HIGH 0x0a4
+
+/* Shared memory selector */
+#define VIRTIO_MMIO_SHM_SEL 0x0ac
+
+/* Shared memory length (64-bit split) */
+#define VIRTIO_MMIO_SHM_LEN_LOW 0x0b0
+#define VIRTIO_MMIO_SHM_LEN_HIGH 0x0b4
+
+/* Shared memory base address (64-bit split) */
+#define VIRTIO_MMIO_SHM_BASE_LOW 0x0b8
+#define VIRTIO_MMIO_SHM_BASE_HIGH 0x0bc
+
+/* Configuration atomicity value */
+#define VIRTIO_MMIO_CONFIG_GENERATION 0x0fc
+
+/* Per-device config space base */
+#define VIRTIO_MMIO_CONFIG 0x100
+
+/* Interrupt flags */
+#define VIRTIO_MMIO_INT_VRING (1 << 0)
+#define VIRTIO_MMIO_INT_CONFIG (1 << 1)
+
+#endif /* _LINUX_VIRTIO_MMIO_H */

--- a/tools/include/linux/virtio_mmio.h
+++ b/tools/include/linux/virtio_mmio.h
@@ -1,0 +1,146 @@
+/*
+ * Virtio platform device driver
+ *
+ * Copyright 2011, ARM Ltd.
+ *
+ * Based on Virtio PCI driver by Anthony Liguori, copyright IBM Corp. 2007
+ *
+ * This header is BSD licensed so anyone can use the definitions to implement
+ * compatible drivers/servers.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of IBM nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL IBM OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#ifndef _LINUX_VIRTIO_MMIO_H
+#define _LINUX_VIRTIO_MMIO_H
+
+/*
+ * Control registers
+ */
+
+/* Magic value ("virt" string) - Read Only */
+#define VIRTIO_MMIO_MAGIC_VALUE 0x000
+
+/* Virtio device version - Read Only */
+#define VIRTIO_MMIO_VERSION 0x004
+
+/* Virtio device ID - Read Only */
+#define VIRTIO_MMIO_DEVICE_ID 0x008
+
+/* Virtio vendor ID - Read Only */
+#define VIRTIO_MMIO_VENDOR_ID 0x00c
+
+/* Bitmask of the features supported by the device (host)
+ * (32 bits per set) - Read Only */
+#define VIRTIO_MMIO_DEVICE_FEATURES 0x010
+
+/* Device (host) features set selector - Write Only */
+#define VIRTIO_MMIO_DEVICE_FEATURES_SEL 0x014
+
+/* Bitmask of features activated by the driver (guest)
+ * (32 bits per set) - Write Only */
+#define VIRTIO_MMIO_DRIVER_FEATURES 0x020
+
+/* Activated features set selector - Write Only */
+#define VIRTIO_MMIO_DRIVER_FEATURES_SEL 0x024
+
+#ifndef VIRTIO_MMIO_NO_LEGACY /* LEGACY DEVICES ONLY! */
+
+/* Guest's memory page size in bytes - Write Only */
+#define VIRTIO_MMIO_GUEST_PAGE_SIZE 0x028
+
+#endif
+
+/* Queue selector - Write Only */
+#define VIRTIO_MMIO_QUEUE_SEL 0x030
+
+/* Maximum size of the currently selected queue - Read Only */
+#define VIRTIO_MMIO_QUEUE_NUM_MAX 0x034
+
+/* Queue size for the currently selected queue - Write Only */
+#define VIRTIO_MMIO_QUEUE_NUM 0x038
+
+#ifndef VIRTIO_MMIO_NO_LEGACY /* LEGACY DEVICES ONLY! */
+
+/* Used Ring alignment for the currently selected queue - Write Only */
+#define VIRTIO_MMIO_QUEUE_ALIGN 0x03c
+
+/* Guest's PFN for the currently selected queue - Read Write */
+#define VIRTIO_MMIO_QUEUE_PFN 0x040
+
+#endif
+
+/* Ready bit for the currently selected queue - Read Write */
+#define VIRTIO_MMIO_QUEUE_READY 0x044
+
+/* Queue notifier - Write Only */
+#define VIRTIO_MMIO_QUEUE_NOTIFY 0x050
+
+/* Interrupt status - Read Only */
+#define VIRTIO_MMIO_INTERRUPT_STATUS 0x060
+
+/* Interrupt acknowledge - Write Only */
+#define VIRTIO_MMIO_INTERRUPT_ACK 0x064
+
+/* Device status register - Read Write */
+#define VIRTIO_MMIO_STATUS 0x070
+
+/* Selected queue's Descriptor Table address, 64 bits in two halves */
+#define VIRTIO_MMIO_QUEUE_DESC_LOW 0x080
+#define VIRTIO_MMIO_QUEUE_DESC_HIGH 0x084
+
+/* Selected queue's Available Ring address, 64 bits in two halves */
+#define VIRTIO_MMIO_QUEUE_AVAIL_LOW 0x090
+#define VIRTIO_MMIO_QUEUE_AVAIL_HIGH 0x094
+
+/* Selected queue's Used Ring address, 64 bits in two halves */
+#define VIRTIO_MMIO_QUEUE_USED_LOW 0x0a0
+#define VIRTIO_MMIO_QUEUE_USED_HIGH 0x0a4
+
+/* Shared memory region id */
+#define VIRTIO_MMIO_SHM_SEL 0x0ac
+
+/* Shared memory region length, 64 bits in two halves */
+#define VIRTIO_MMIO_SHM_LEN_LOW 0x0b0
+#define VIRTIO_MMIO_SHM_LEN_HIGH 0x0b4
+
+/* Shared memory region base address, 64 bits in two halves */
+#define VIRTIO_MMIO_SHM_BASE_LOW 0x0b8
+#define VIRTIO_MMIO_SHM_BASE_HIGH 0x0bc
+
+/* Configuration atomicity value */
+#define VIRTIO_MMIO_CONFIG_GENERATION 0x0fc
+
+/* The config space is defined by each driver as
+ * the per-driver configuration space - Read Write */
+#define VIRTIO_MMIO_CONFIG 0x100
+
+/*
+ * Interrupt flags (re: interrupt status & acknowledge registers)
+ */
+
+#define VIRTIO_MMIO_INT_VRING (1 << 0)
+#define VIRTIO_MMIO_INT_CONFIG (1 << 1)
+
+#endif


### PR DESCRIPTION
OpenHarmony use LLVM instead of CC. And its sysroot lacks virtio_mmio definitions. And its Linux Kernel version is 6.6. So this pr:
1. Keep tools compiler selection flexible: only fall back to CROSS_COMPILE gcc when CC is the default from make, so explicit CC overrides still work. 
2. Add a local virtio mmio UAPI compatibility header for environments where the cross sysroot lacks linux virtio_mmio definitions. 
3. Make demo binaries optional via BUILD_DEMOS (default off), so the main userspace hvisor binary is not blocked by optional rpmsg demo headers. 
4. Update ivc driver to include linux version checks and use the newer class_create API on Linux 6.4+, while keeping backward-compatible behavior for older kernels.

