### PR TITLE
refactor: centralize logging lifecycle ownership in main

### DIFF
--- a/tools/hvisor.c
+++ b/tools/hvisor.c
@@ -1008,6 +1008,10 @@ static int zone_list(int argc, char *argv[]) {
 int main(int argc, char *argv[]) {
     int err = 0;
 
+    multithread_log_init();
+    initialize_log();
+    atexit(multithread_log_exit);
+
     if (argc < 3)
         help(1);
 

--- a/tools/include/log.h
+++ b/tools/include/log.h
@@ -33,6 +33,15 @@ enum { LOG_TRACE, LOG_DEBUG, LOG_INFO, LOG_WARN, LOG_ERROR, LOG_FATAL };
 #define log_fatal(...) log_log(LOG_FATAL, __FILE__, __LINE__, __VA_ARGS__)
 
 const char *log_level_string(int level);
+
+/**
+ * @brief Configure the default syslog log level used by hvisor tools.
+ *
+ * This function applies the compile-time log level policy shared by the main
+ * CLI and the virtio backend after syslog has been initialized.
+ */
+void initialize_log(void);
+
 void log_set_level(int level);
 void log_set_quiet(bool enable);
 

--- a/tools/log.c
+++ b/tools/log.c
@@ -49,6 +49,16 @@ static const int syslog_levels[] = {LOG_DEBUG,   LOG_DEBUG, LOG_INFO,
 
 const char *log_level_string(int level) { return level_strings[level]; }
 
+void initialize_log(void) {
+    int log_level;
+#ifdef HLOG
+    log_level = HLOG;
+#else
+    log_level = LOG_WARN;
+#endif
+    log_set_level(log_level);
+}
+
 void log_set_level(int level) { L.level = level; }
 
 void log_set_quiet(bool enable) { L.quiet = enable; }

--- a/tools/virtio/include/virtio.h
+++ b/tools/virtio/include/virtio.h
@@ -210,8 +210,6 @@ void virtio_close();
 
 void handle_virtio_requests();
 
-void initialize_log();
-
 int virtio_init();
 
 int create_virtio_device_from_json(cJSON *device_json, int zone_id);

--- a/tools/virtio/virtio.c
+++ b/tools/virtio/virtio.c
@@ -1026,7 +1026,7 @@ void virtio_close() {
                        zone_mem[i][j][MEM_SIZE]);
             }
     }
-    multithread_log_exit();
+
     log_warn("virtio daemon exit successfully");
 }
 

--- a/tools/virtio/virtio.c
+++ b/tools/virtio/virtio.c
@@ -1243,16 +1243,6 @@ void handle_virtio_requests(void) {
     }
 }
 
-void initialize_log() {
-    int log_level;
-#ifdef HLOG
-    log_level = HLOG;
-#else
-    log_level = LOG_WARN;
-#endif
-    log_set_level(log_level);
-}
-
 int virtio_init() {
     // The higher log level is, the faster virtio-blk will be.
     int err;
@@ -1264,10 +1254,6 @@ int virtio_init() {
 
     // Set process name
     prctl(PR_SET_NAME, "hvisor-virtio", 0, 0, 0);
-
-    // Initialize logging
-    multithread_log_init();
-    initialize_log();
 
     log_info("hvisor init");
     ko_fd = open("/dev/hvisor", O_RDWR);


### PR DESCRIPTION
Move logging lifecycle ownership to the main CLI entrypoint.

## Changes

- Initialize syslog once in `main()`
- Move `initialize_log()` to the common logging module
- Remove redundant logging init from `virtio_init()`
- Stop closing global logging from `virtio_close()`

## References

Closes: #88 
