### PR TITLE
fix: resolve `syslog.h` macro conflict with log level enum in `log.c`

### DIFF
--- a/tools/log.c
+++ b/tools/log.c
@@ -34,6 +34,17 @@
 #include <pthread.h>
 #include <stdarg.h>
 #include <stdio.h>
+
+void initialize_log(void) {
+    int log_level;
+#ifdef HLOG
+    log_level = HLOG;
+#else
+    log_level = LOG_WARN;
+#endif
+    log_set_level(log_level);
+}
+
 #include <syslog.h>
 
 static struct {
@@ -48,16 +59,6 @@ static const int syslog_levels[] = {LOG_DEBUG,   LOG_DEBUG, LOG_INFO,
                                     LOG_WARNING, LOG_ERR,   LOG_CRIT};
 
 const char *log_level_string(int level) { return level_strings[level]; }
-
-void initialize_log(void) {
-    int log_level;
-#ifdef HLOG
-    log_level = HLOG;
-#else
-    log_level = LOG_WARN;
-#endif
-    log_set_level(log_level);
-}
 
 void log_set_level(int level) { L.level = level; }
 


### PR DESCRIPTION
This PR moves `initialize_log()` before the `<syslog.h>` include so the `HLOG` compile-time macro resolves to our enum values instead of being silently overridden by `syslog.h` macros.

Shall we consider migrating to `syslog.h` priority constants directly to eliminate the dual level system and the translation table?
