### PR TITLE
Fix Syslog Dismiss Problem

### DIFF
--- a/tools/Makefile
+++ b/tools/Makefile
@@ -32,7 +32,23 @@ $(error "Unsupported architecture $(ARCH)")
 	endif
 endif
 
-CFLAGS := -Wall -Wextra -DLOG_USE_COLOR -DHLOG=$(LOG) -pthread
+ifeq ($(LOG),LOG_TRACE)
+	HLOG_LEVEL := 0
+else ifeq ($(LOG),LOG_DEBUG)
+	HLOG_LEVEL := 1
+else ifeq ($(LOG),LOG_INFO)
+	HLOG_LEVEL := 2
+else ifeq ($(LOG),LOG_WARN)
+	HLOG_LEVEL := 3
+else ifeq ($(LOG),LOG_ERROR)
+	HLOG_LEVEL := 4
+else ifeq ($(LOG),LOG_FATAL)
+	HLOG_LEVEL := 5
+else
+$(error LOG must be one of: LOG_TRACE LOG_DEBUG LOG_INFO LOG_WARN LOG_ERROR LOG_FATAL)
+endif
+
+CFLAGS := -Wall -Wextra -DLOG_USE_COLOR -DHLOG=$(HLOG_LEVEL) -pthread
 
 # Conditionally add sysroot if ROOT is set
 # Otherwise use default flags from cross-compiler


### PR DESCRIPTION
The built-in macro definitions in syslog.h override the output level definitions inside hvisor-tool.
his commit bypasses this issue by determining the values earlier in the Makefile.