### PR TITLE
fix: use 1ULL instead of 1 in CPU bitmap shift to avoid UB

### DIFF
--- a/tools/hvisor.c
+++ b/tools/hvisor.c
@@ -698,7 +698,7 @@ static int zone_start_from_json(const char *json_config_path,
 
     for (int i = 0; i < num_cpus; i++) {
         config->cpus |=
-            (1 << SAFE_CJSON_GET_ARRAY_ITEM(cpus_json, i)->valueint);
+            (1ULL << SAFE_CJSON_GET_ARRAY_ITEM(cpus_json, i)->valueint);
     }
 
     int num_memory_regions = SAFE_CJSON_GET_ARRAY_SIZE(memory_regions_json);


### PR DESCRIPTION
## Summary

- Fix undefined behavior in CPU bitmap construction when `cpu_id >= 31`
- `1 << cpu_id` uses a signed `int` — `1 << 31` is UB (sign-bit overflow),
  and `1 << 32` is UB on 64-bit (shift >= width of type)
- Change to `1ULL << cpu_id` for a well-defined 64-bit shift
- Current max platform is 16 CPUs, but this is a latent bug waiting to trigger
  on any platform with 31+ CPUs or with a misconfigured JSON config
