### PR TITLE
refactor: clean up log level system, use syslog constants directly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ help:
 	@echo ""
 	@echo "Environment variables:"
 	@echo "  ARCH=arm64|riscv|loongarch   Target architecture (required)"
-	@echo "  LOG=LEVEL                    Log level (default: LOG_INFO)"
+	@echo "  LOG=LEVEL                    Log level: LOG_DEBUG LOG_INFO LOG_WARNING LOG_ERR LOG_CRIT (default: LOG_INFO)"
 	@echo "  KDIR=path                    Linux kernel source path (required)"
 	@echo "  VIRTIO_GPU=y|n               Enable GPU support (default: n)"
 

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -32,20 +32,18 @@ $(error "Unsupported architecture $(ARCH)")
 	endif
 endif
 
-ifeq ($(LOG),LOG_TRACE)
+ifeq ($(LOG),LOG_DEBUG)
 	HLOG_LEVEL := 0
-else ifeq ($(LOG),LOG_DEBUG)
-	HLOG_LEVEL := 1
 else ifeq ($(LOG),LOG_INFO)
-	HLOG_LEVEL := 2
+	HLOG_LEVEL := 1
 else ifeq ($(LOG),LOG_WARN)
-	HLOG_LEVEL := 3
+	HLOG_LEVEL := 2
 else ifeq ($(LOG),LOG_ERROR)
-	HLOG_LEVEL := 4
+	HLOG_LEVEL := 3
 else ifeq ($(LOG),LOG_FATAL)
-	HLOG_LEVEL := 5
+	HLOG_LEVEL := 4
 else
-$(error LOG must be one of: LOG_TRACE LOG_DEBUG LOG_INFO LOG_WARN LOG_ERROR LOG_FATAL)
+$(error LOG must be one of: LOG_DEBUG LOG_INFO LOG_WARN LOG_ERROR LOG_FATAL)
 endif
 
 CFLAGS := -Wall -Wextra -DLOG_USE_COLOR -DHLOG=$(HLOG_LEVEL) -pthread

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -33,20 +33,20 @@ $(error "Unsupported architecture $(ARCH)")
 endif
 
 ifeq ($(LOG),LOG_DEBUG)
-	HLOG_LEVEL := 0
+	HLOG_LEVEL := LOG_DEBUG
 else ifeq ($(LOG),LOG_INFO)
-	HLOG_LEVEL := 1
+	HLOG_LEVEL := LOG_INFO
 else ifeq ($(LOG),LOG_WARN)
-	HLOG_LEVEL := 2
+	HLOG_LEVEL := LOG_WARNING
 else ifeq ($(LOG),LOG_ERROR)
-	HLOG_LEVEL := 3
+	HLOG_LEVEL := LOG_ERR
 else ifeq ($(LOG),LOG_FATAL)
-	HLOG_LEVEL := 4
+	HLOG_LEVEL := LOG_CRIT
 else
 $(error LOG must be one of: LOG_DEBUG LOG_INFO LOG_WARN LOG_ERROR LOG_FATAL)
 endif
 
-CFLAGS := -Wall -Wextra -DLOG_USE_COLOR -DHLOG=$(HLOG_LEVEL) -pthread
+CFLAGS := -Wall -Wextra -DHLOG=$(HLOG_LEVEL) -pthread
 
 # Conditionally add sysroot if ROOT is set
 # Otherwise use default flags from cross-compiler

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -32,21 +32,7 @@ $(error "Unsupported architecture $(ARCH)")
 	endif
 endif
 
-ifeq ($(LOG),LOG_DEBUG)
-	HLOG_LEVEL := LOG_DEBUG
-else ifeq ($(LOG),LOG_INFO)
-	HLOG_LEVEL := LOG_INFO
-else ifeq ($(LOG),LOG_WARN)
-	HLOG_LEVEL := LOG_WARNING
-else ifeq ($(LOG),LOG_ERROR)
-	HLOG_LEVEL := LOG_ERR
-else ifeq ($(LOG),LOG_FATAL)
-	HLOG_LEVEL := LOG_CRIT
-else
-$(error LOG must be one of: LOG_DEBUG LOG_INFO LOG_WARN LOG_ERROR LOG_FATAL)
-endif
-
-CFLAGS := -Wall -Wextra -DHLOG=$(HLOG_LEVEL) -pthread
+CFLAGS := -Wall -Wextra -DHLOG=$(LOG) -pthread
 
 # Conditionally add sysroot if ROOT is set
 # Otherwise use default flags from cross-compiler

--- a/tools/include/log.h
+++ b/tools/include/log.h
@@ -23,9 +23,8 @@
 
 #define LOG_VERSION "0.1.0"
 
-enum { LOG_TRACE, LOG_DEBUG, LOG_INFO, LOG_WARN, LOG_ERROR, LOG_FATAL };
+enum { LOG_DEBUG, LOG_INFO, LOG_WARN, LOG_ERROR, LOG_FATAL };
 
-#define log_trace(...) log_log(LOG_TRACE, __FILE__, __LINE__, __VA_ARGS__)
 #define log_debug(...) log_log(LOG_DEBUG, __FILE__, __LINE__, __VA_ARGS__)
 #define log_info(...) log_log(LOG_INFO, __FILE__, __LINE__, __VA_ARGS__)
 #define log_warn(...) log_log(LOG_WARN, __FILE__, __LINE__, __VA_ARGS__)

--- a/tools/include/log.h
+++ b/tools/include/log.h
@@ -23,15 +23,13 @@
 
 #define LOG_VERSION "0.1.0"
 
-enum { LOG_DEBUG, LOG_INFO, LOG_WARN, LOG_ERROR, LOG_FATAL };
+#include <syslog.h>
 
 #define log_debug(...) log_log(LOG_DEBUG, __FILE__, __LINE__, __VA_ARGS__)
 #define log_info(...) log_log(LOG_INFO, __FILE__, __LINE__, __VA_ARGS__)
-#define log_warn(...) log_log(LOG_WARN, __FILE__, __LINE__, __VA_ARGS__)
-#define log_error(...) log_log(LOG_ERROR, __FILE__, __LINE__, __VA_ARGS__)
-#define log_fatal(...) log_log(LOG_FATAL, __FILE__, __LINE__, __VA_ARGS__)
-
-const char *log_level_string(int level);
+#define log_warn(...) log_log(LOG_WARNING, __FILE__, __LINE__, __VA_ARGS__)
+#define log_error(...) log_log(LOG_ERR, __FILE__, __LINE__, __VA_ARGS__)
+#define log_fatal(...) log_log(LOG_CRIT, __FILE__, __LINE__, __VA_ARGS__)
 
 /**
  * @brief Configure the default syslog log level used by hvisor tools.

--- a/tools/log.c
+++ b/tools/log.c
@@ -52,11 +52,11 @@ static struct {
     bool quiet;
 } L;
 
-static const char *level_strings[] = {"TRACE", "DEBUG", "INFO",
-                                      "WARN",  "ERROR", "FATAL"};
+static const char *level_strings[] = {"DEBUG", "INFO", "WARN", "ERROR",
+                                      "FATAL"};
 
-static const int syslog_levels[] = {LOG_DEBUG,   LOG_DEBUG, LOG_INFO,
-                                    LOG_WARNING, LOG_ERR,   LOG_CRIT};
+static const int syslog_levels[] = {LOG_DEBUG, LOG_INFO, LOG_WARNING, LOG_ERR,
+                                    LOG_CRIT};
 
 const char *log_level_string(int level) { return level_strings[level]; }
 

--- a/tools/log.c
+++ b/tools/log.c
@@ -40,32 +40,22 @@ void initialize_log(void) {
 #ifdef HLOG
     log_level = HLOG;
 #else
-    log_level = LOG_WARN;
+    log_level = LOG_WARNING;
 #endif
     log_set_level(log_level);
 }
-
-#include <syslog.h>
 
 static struct {
     int level;
     bool quiet;
 } L;
 
-static const char *level_strings[] = {"DEBUG", "INFO", "WARN", "ERROR",
-                                      "FATAL"};
-
-static const int syslog_levels[] = {LOG_DEBUG, LOG_INFO, LOG_WARNING, LOG_ERR,
-                                    LOG_CRIT};
-
-const char *log_level_string(int level) { return level_strings[level]; }
-
 void log_set_level(int level) { L.level = level; }
 
 void log_set_quiet(bool enable) { L.quiet = enable; }
 
 void log_log(int level, const char *file, int line, const char *fmt, ...) {
-    if (L.quiet || level < L.level) {
+    if (L.quiet || level > L.level) {
         return;
     }
 
@@ -75,7 +65,7 @@ void log_log(int level, const char *file, int line, const char *fmt, ...) {
     char buf[2048];
     vsnprintf(buf, sizeof(buf), fmt, ap);
     va_end(ap);
-    syslog(syslog_levels[level], "%s:%d: %s", file, line, buf);
+    syslog(level, "%s:%d: %s", file, line, buf);
 }
 
 void multithread_log_init() {

--- a/tools/virtio/devices/console/virtio_console.c
+++ b/tools/virtio/devices/console/virtio_console.c
@@ -75,7 +75,7 @@ static void virtio_console_event_handler(int fd, int epoll_type, void *param) {
             free(iov);
             break;
         } else if (len < 0) {
-            log_trace("Failed to read from console, errno is %d", errno);
+            log_debug("Failed to read from console, errno is %d", errno);
             vq->last_avail_idx--;
             free(iov);
             break;

--- a/tools/virtio/virtio.c
+++ b/tools/virtio/virtio.c
@@ -330,7 +330,7 @@ void init_mmio_regs(VirtMmioRegs *regs, VirtioDeviceType type) {
 
 void virtio_dev_reset(VirtIODevice *vdev) {
     // When driver read first 4 encoded messages, it will reset dev.
-    log_trace("virtio dev reset");
+    log_debug("virtio dev reset");
     vdev->regs.status = 0;
     vdev->regs.interrupt_status = 0;
     vdev->regs.interrupt_count = 0;
@@ -809,7 +809,7 @@ void virtio_mmio_write(VirtIODevice *vdev, uint64_t offset, uint64_t value,
                   virtio_device_type_to_string(vdev->type));
 
         if (value < vdev->vqs_len) {
-            log_trace("queue notify ready, handler addr is %#x",
+            log_debug("queue notify ready, handler addr is %#x",
                       vqs[value].notify_handler);
             vqs[value].notify_handler(vdev, &vqs[value]);
         }
@@ -992,7 +992,7 @@ int virtio_handle_req(volatile struct device_req *req) {
         virtio_finish_cfg_req(req->src_cpu, value);
     }
 
-    log_trace("src_zone is %d, src_cpu is %lld", req->src_zone, req->src_cpu);
+    log_debug("src_zone is %d, src_cpu is %lld", req->src_zone, req->src_cpu);
     return 0;
 }
 


### PR DESCRIPTION
Remove the custom log level enum and `syslog_levels[]` mapping layer.

Macros now use syslog constants (`LOG_DEBUG`, `LOG_INFO`, `LOG_WARNING`, `LOG_ERR`, `LOG_CRIT`) directly. Merge redundant log_trace into log_debug.

Also drop the Makefile `ifeq` chain, just pass `$(LOG)` directly to `-DHLOG`.
