### PR TITLE
virtio-net: fix UDP TX stall and improve TCP throughput

### DIFF
--- a/tools/virtio/devices/net/virtio_net.c
+++ b/tools/virtio/devices/net/virtio_net.c
@@ -238,13 +238,21 @@ static void virtq_tx_handle_one_request(VirtIODevice *vdev, VirtQueue *vq) {
 int virtio_net_txq_notify_handler(VirtIODevice *vdev, VirtQueue *vq) {
     log_debug("virtio_net_txq_notify_handler");
     virtqueue_disable_notify(vq);
-    while (!virtqueue_is_empty(vq)) {
-        virtq_tx_handle_one_request(vdev, vq);
+    for (;;) {
+        while (!virtqueue_is_empty(vq)) {
+            virtq_tx_handle_one_request(vdev, vq);
+        }
+        virtqueue_enable_notify(vq);
+        // Re-check: guest may have added descriptors between our last
+        // empty check and enable_notify.  Without this, UDP streams
+        // lose descriptors permanently because each sendto() issues
+        // exactly one kick and the suppressed notification never fires.
+        if (!virtqueue_is_empty(vq)) {
+            virtqueue_disable_notify(vq);
+            continue;
+        }
+        break;
     }
-    virtqueue_enable_notify(vq);
-    // TODO: Can we don't inject irq when send packets to improve performance?
-    // Linux will recycle the used ring when send packets.
-    // virtio_inject_irq(vq);
     return 0;
 }
 

--- a/tools/virtio/devices/net/virtio_net.c
+++ b/tools/virtio/devices/net/virtio_net.c
@@ -11,6 +11,11 @@
 #include "virtio_net.h"
 #include "event_monitor.h"
 #include "log.h"
+
+// Max iov entries for a net descriptor chain.  Typical packets use 1-3
+// descriptors; 8 is ample for the stack-allocated iov buffer used with
+// process_descriptor_chain_buf().
+#define NET_IOV_MAX 8
 #include "virtio.h"
 #include <errno.h>
 #include <fcntl.h>
@@ -107,11 +112,10 @@ void virtio_net_event_handler(int fd, int epoll_type, void *param) {
     log_debug("virtio_net_event_handler");
     VirtIODevice *vdev = param;
     void *vnet_header;
-    struct iovec *iov, *iov_packet;
+    struct iovec *iov_packet;
     NetDev *net = vdev->dev;
     VirtQueue *vq = &vdev->vqs[NET_QUEUE_RX];
-    int n, len;
-    uint16_t idx;
+    int len;
     size_t header_len = get_nethdr_size(vdev);
     if (fd != net->tapfd || !(epoll_type & EPOLLIN)) {
         log_error("invalid event");
@@ -135,39 +139,47 @@ void virtio_net_event_handler(int fd, int epoll_type, void *param) {
         return;
     }
     while (!virtqueue_is_empty(vq)) {
-        n = process_descriptor_chain(vq, &idx, &iov, NULL, 0, false);
+        struct iovec in_buf[NET_IOV_MAX];
+        struct VirtioBufConfig cfg = {
+            .in_iov = in_buf,
+            .max_in = NET_IOV_MAX,
+        };
+        struct VirtioRequest req;
+        uint16_t idx = vq->avail_ring->ring[vq->last_avail_idx & (vq->num - 1)];
+        int n = process_descriptor_chain_buf(vq, idx, &cfg, &req);
         if (n < 1 || n > VIRTQUEUE_NET_MAX_SIZE) {
             log_error("process_descriptor_chain failed");
-            goto free_iov;
+            if (n >= 1)
+                update_used_ring(vq, idx, 0);
+            break;
         }
-        vnet_header = iov[0].iov_base;
-        iov_packet = rm_iov_header(iov, &n, header_len);
+
+        // RX: all buffers are VRING_DESC_F_WRITE → in_iov
+        vnet_header = req.in_iov[0].iov_base;
+        iov_packet = rm_iov_header(req.in_iov, &req.in_count, header_len);
         if (iov_packet == NULL) {
             update_used_ring(vq, idx, 0);
-            goto free_iov;
+            break;
         }
         // Read a packet from tap device
-        len = readv(net->tapfd, iov_packet, n);
+        len = readv(net->tapfd, iov_packet, req.in_count);
 
         if (len < 0 && errno == EWOULDBLOCK) {
             // No more packets from tapfd, restore last_avail_idx.
             log_info("no more packets");
             vq->last_avail_idx--;
-            free(iov);
             break;
         }
 
         if (len < 0) {
             log_error("readv from tap failed, errno %d", errno);
             update_used_ring(vq, idx, 0);
-            free(iov);
             break;
         }
 
         if (len == 0) {
             log_error("tap device EOF (closed or bridge down)");
             update_used_ring(vq, idx, 0);
-            free(iov);
             net->rx_ready = 0;
             break;
         }
@@ -178,20 +190,20 @@ void virtio_net_event_handler(int fd, int epoll_type, void *param) {
         }
 
         update_used_ring(vq, idx, len + header_len);
-        free(iov);
     }
 
     virtio_inject_irq(vq);
-    return;
-free_iov:
-    free(iov);
 }
 
 static void virtq_tx_handle_one_request(VirtIODevice *vdev, VirtQueue *vq) {
-    struct iovec *iov = NULL;
-    int i, n;
-    int packet_len, all_len; // all_len include the header length.
-    uint16_t idx;
+    struct iovec out_buf[NET_IOV_MAX];
+    struct VirtioBufConfig cfg = {
+        .out_iov = out_buf,
+        .max_out = NET_IOV_MAX - 1,
+    };
+    struct VirtioRequest req;
+    int i, n, packet_len, all_len;
+    uint16_t idx = vq->avail_ring->ring[vq->last_avail_idx & (vq->num - 1)];
     char pad[64] = {0};
     ssize_t len;
     NetDev *net = vdev->dev;
@@ -201,38 +213,38 @@ static void virtq_tx_handle_one_request(VirtIODevice *vdev, VirtQueue *vq) {
         return;
     }
 
-    n = process_descriptor_chain(vq, &idx, &iov, NULL, 1, false);
+    // NET_IOV_MAX - 1 reserves one slot for ethernet padding
+    n = process_descriptor_chain_buf(vq, idx, &cfg, &req);
     if (n < 1) {
         return;
     }
 
-    if ((size_t)iov[0].iov_len < header_len) {
+    // TX: no descriptors are VRING_DESC_F_WRITE → out_iov
+    if ((size_t)req.out_iov[0].iov_len < header_len) {
         log_error("malformed TX packet: iov[0] too small for header");
         update_used_ring(vq, idx, 0);
-        free(iov);
         return;
     }
 
-    for (i = 0, all_len = 0; i < n; i++)
-        all_len += iov[i].iov_len;
+    for (i = 0, all_len = 0; i < req.out_count; i++)
+        all_len += req.out_iov[i].iov_len;
 
     packet_len = all_len - header_len;
-    iov[0].iov_base += header_len;
-    iov[0].iov_len -= header_len;
+    req.out_iov[0].iov_base += header_len;
+    req.out_iov[0].iov_len -= header_len;
     log_debug("packet send: %d bytes", packet_len);
 
     // The mininum packet for data link layer is 64 bytes.
     if (packet_len < 64) {
-        iov[n].iov_base = pad;
-        iov[n].iov_len = 64 - packet_len;
-        n++;
+        req.out_iov[req.out_count].iov_base = pad;
+        req.out_iov[req.out_count].iov_len = 64 - packet_len;
+        req.out_count++;
     }
-    len = writev(net->tapfd, iov, n);
+    len = writev(net->tapfd, req.out_iov, req.out_count);
     if (len < 0) {
         log_error("write tap failed, errno %d", errno);
     }
     update_used_ring(vq, idx, all_len);
-    free(iov);
 }
 
 int virtio_net_txq_notify_handler(VirtIODevice *vdev, VirtQueue *vq) {

--- a/tools/virtio/devices/net/virtio_net.c
+++ b/tools/virtio/devices/net/virtio_net.c
@@ -144,8 +144,10 @@ void virtio_net_event_handler(int fd, int epoll_type, void *param) {
         }
         vnet_header = iov[0].iov_base;
         iov_packet = rm_iov_header(iov, &n, header_len);
-        if (iov_packet == NULL)
+        if (iov_packet == NULL) {
+            update_used_ring(vq, idx, 0);
             goto free_iov;
+        }
         // Read a packet from tap device
         len = readv(net->tapfd, iov_packet, n);
 

--- a/tools/virtio/devices/net/virtio_net.c
+++ b/tools/virtio/devices/net/virtio_net.c
@@ -191,6 +191,13 @@ static void virtq_tx_handle_one_request(VirtIODevice *vdev, VirtQueue *vq) {
         return;
     }
 
+    if ((size_t)iov[0].iov_len < header_len) {
+        log_error("malformed TX packet: iov[0] too small for header");
+        update_used_ring(vq, idx, 0);
+        free(iov);
+        return;
+    }
+
     for (i = 0, all_len = 0; i < n; i++)
         all_len += iov[i].iov_len;
 

--- a/tools/virtio/devices/net/virtio_net.c
+++ b/tools/virtio/devices/net/virtio_net.c
@@ -138,6 +138,9 @@ void virtio_net_event_handler(int fd, int epoll_type, void *param) {
         virtio_inject_irq(vq);
         return;
     }
+    uint16_t batch_indices[VIRTQUEUE_NET_MAX_SIZE];
+    uint32_t batch_lens[VIRTQUEUE_NET_MAX_SIZE];
+    int batch_count = 0;
     while (!virtqueue_is_empty(vq)) {
         struct iovec in_buf[NET_IOV_MAX];
         struct VirtioBufConfig cfg = {
@@ -149,8 +152,11 @@ void virtio_net_event_handler(int fd, int epoll_type, void *param) {
         int n = process_descriptor_chain_buf(vq, idx, &cfg, &req);
         if (n < 1 || n > VIRTQUEUE_NET_MAX_SIZE) {
             log_error("process_descriptor_chain failed");
-            if (n >= 1)
-                update_used_ring(vq, idx, 0);
+            if (n >= 1) {
+                batch_indices[batch_count] = idx;
+                batch_lens[batch_count] = 0;
+                batch_count++;
+            }
             break;
         }
 
@@ -158,7 +164,9 @@ void virtio_net_event_handler(int fd, int epoll_type, void *param) {
         vnet_header = req.in_iov[0].iov_base;
         iov_packet = rm_iov_header(req.in_iov, &req.in_count, header_len);
         if (iov_packet == NULL) {
-            update_used_ring(vq, idx, 0);
+            batch_indices[batch_count] = idx;
+            batch_lens[batch_count] = 0;
+            batch_count++;
             break;
         }
         // Read a packet from tap device
@@ -173,13 +181,17 @@ void virtio_net_event_handler(int fd, int epoll_type, void *param) {
 
         if (len < 0) {
             log_error("readv from tap failed, errno %d", errno);
-            update_used_ring(vq, idx, 0);
+            batch_indices[batch_count] = idx;
+            batch_lens[batch_count] = 0;
+            batch_count++;
             break;
         }
 
         if (len == 0) {
             log_error("tap device EOF (closed or bridge down)");
-            update_used_ring(vq, idx, 0);
+            batch_indices[batch_count] = idx;
+            batch_lens[batch_count] = 0;
+            batch_count++;
             net->rx_ready = 0;
             break;
         }
@@ -189,13 +201,19 @@ void virtio_net_event_handler(int fd, int epoll_type, void *param) {
             ((NetHdr *)vnet_header)->num_buffers = 1;
         }
 
-        update_used_ring(vq, idx, len + header_len);
+        batch_indices[batch_count] = idx;
+        batch_lens[batch_count] = len + header_len;
+        batch_count++;
     }
 
+    if (batch_count > 0)
+        update_used_ring_batch(vq, batch_indices, batch_lens, batch_count);
     virtio_inject_irq(vq);
 }
 
-static void virtq_tx_handle_one_request(VirtIODevice *vdev, VirtQueue *vq) {
+static void virtq_tx_handle_one_request(VirtIODevice *vdev, VirtQueue *vq,
+                                        uint16_t *out_indices,
+                                        uint32_t *out_lens, int *out_count) {
     struct iovec out_buf[NET_IOV_MAX];
     struct VirtioBufConfig cfg = {
         .out_iov = out_buf,
@@ -222,7 +240,9 @@ static void virtq_tx_handle_one_request(VirtIODevice *vdev, VirtQueue *vq) {
     // TX: no descriptors are VRING_DESC_F_WRITE → out_iov
     if ((size_t)req.out_iov[0].iov_len < header_len) {
         log_error("malformed TX packet: iov[0] too small for header");
-        update_used_ring(vq, idx, 0);
+        out_indices[*out_count] = idx;
+        out_lens[*out_count] = 0;
+        (*out_count)++;
         return;
     }
 
@@ -244,15 +264,26 @@ static void virtq_tx_handle_one_request(VirtIODevice *vdev, VirtQueue *vq) {
     if (len < 0) {
         log_error("write tap failed, errno %d", errno);
     }
-    update_used_ring(vq, idx, all_len);
+    out_indices[*out_count] = idx;
+    out_lens[*out_count] = all_len;
+    (*out_count)++;
 }
 
 int virtio_net_txq_notify_handler(VirtIODevice *vdev, VirtQueue *vq) {
     log_debug("virtio_net_txq_notify_handler");
     virtqueue_disable_notify(vq);
+    uint16_t batch_indices[VIRTQUEUE_NET_MAX_SIZE];
+    uint32_t batch_lens[VIRTQUEUE_NET_MAX_SIZE];
+    int batch_count = 0;
     for (;;) {
         while (!virtqueue_is_empty(vq)) {
-            virtq_tx_handle_one_request(vdev, vq);
+            virtq_tx_handle_one_request(vdev, vq, batch_indices, batch_lens,
+                                        &batch_count);
+        }
+        if (batch_count > 0) {
+            update_used_ring_batch(vq, batch_indices, batch_lens, batch_count);
+            batch_count = 0;
+            virtio_inject_irq(vq);
         }
         virtqueue_enable_notify(vq);
         // Re-check: guest may have added descriptors between our last

--- a/tools/virtio/devices/net/virtio_net.c
+++ b/tools/virtio/devices/net/virtio_net.c
@@ -21,9 +21,6 @@
 #include <sys/ioctl.h>
 #include <sys/uio.h>
 #include <unistd.h>
-// The max bytes of a packet in data link layer is 1518 bytes.
-static uint8_t trashbuf[1600];
-
 NetDev *init_net_dev(uint8_t mac[]) {
     NetDev *dev = malloc(sizeof(NetDev));
     dev->config.mac[0] = mac[0];
@@ -126,6 +123,7 @@ void virtio_net_event_handler(int fd, int epoll_type, void *param) {
     }
 
     // if vq is not setup, drop the packet
+    uint8_t trashbuf[1600];
     if (!net->rx_ready) {
         read(net->tapfd, trashbuf, sizeof(trashbuf));
         return;

--- a/tools/virtio/devices/net/virtio_net.c
+++ b/tools/virtio/devices/net/virtio_net.c
@@ -159,6 +159,13 @@ void virtio_net_event_handler(int fd, int epoll_type, void *param) {
             break;
         }
 
+        if (len < 0) {
+            log_error("readv from tap failed, errno %d", errno);
+            update_used_ring(vq, idx, 0);
+            free(iov);
+            break;
+        }
+
         memset(vnet_header, 0, header_len);
         if (vdev->regs.drv_feature & (1ULL << VIRTIO_F_VERSION_1)) {
             ((NetHdr *)vnet_header)->num_buffers = 1;

--- a/tools/virtio/devices/net/virtio_net.c
+++ b/tools/virtio/devices/net/virtio_net.c
@@ -166,6 +166,14 @@ void virtio_net_event_handler(int fd, int epoll_type, void *param) {
             break;
         }
 
+        if (len == 0) {
+            log_error("tap device EOF (closed or bridge down)");
+            update_used_ring(vq, idx, 0);
+            free(iov);
+            net->rx_ready = 0;
+            break;
+        }
+
         memset(vnet_header, 0, header_len);
         if (vdev->regs.drv_feature & (1ULL << VIRTIO_F_VERSION_1)) {
             ((NetHdr *)vnet_header)->num_buffers = 1;

--- a/tools/virtio/devices/net/virtio_net.c
+++ b/tools/virtio/devices/net/virtio_net.c
@@ -177,7 +177,7 @@ static void virtq_tx_handle_one_request(VirtIODevice *vdev, VirtQueue *vq) {
     int i, n;
     int packet_len, all_len; // all_len include the header length.
     uint16_t idx;
-    static char pad[64];
+    char pad[64] = {0};
     ssize_t len;
     NetDev *net = vdev->dev;
     size_t header_len = get_nethdr_size(vdev);

--- a/tools/virtio/devices/net/virtio_net.c
+++ b/tools/virtio/devices/net/virtio_net.c
@@ -230,7 +230,7 @@ static void virtq_tx_handle_one_request(VirtIODevice *vdev, VirtQueue *vq,
         log_error("write tap failed, errno %d", errno);
     }
     out_indices[*out_count] = idx;
-    out_lens[*out_count] = all_len;
+    out_lens[*out_count] = (len < 0) ? 0 : all_len;
     (*out_count)++;
 }
 

--- a/tools/virtio/devices/net/virtio_net.c
+++ b/tools/virtio/devices/net/virtio_net.c
@@ -127,12 +127,13 @@ void virtio_net_event_handler(int fd, int epoll_type, void *param) {
         uint16_t idx = vq->avail_ring->ring[vq->last_avail_idx & (vq->num - 1)];
         int n = process_descriptor_chain_buf(vq, idx, &cfg, &req);
         if (n < 1 || n > VIRTQUEUE_NET_MAX_SIZE) {
-            log_error("process_descriptor_chain failed");
-            if (n >= 1) {
-                batch_indices[batch_count] = idx;
-                batch_lens[batch_count] = 0;
-                batch_count++;
+            log_error("process_descriptor_chain_buf failed: %d", n);
+            if (n < 1) {
+                vq->last_avail_idx++;
             }
+            batch_indices[batch_count] = idx;
+            batch_lens[batch_count] = 0;
+            batch_count++;
             break;
         }
 
@@ -193,6 +194,11 @@ static void virtq_tx_handle_one_request(VirtIODevice *vdev, VirtQueue *vq,
 
     int n = process_descriptor_chain_buf(vq, idx, &cfg, &req);
     if (n < 1) {
+        log_error("process_descriptor_chain_buf failed: %d", n);
+        vq->last_avail_idx++;
+        out_indices[*out_count] = idx;
+        out_lens[*out_count] = 0;
+        (*out_count)++;
         return;
     }
 

--- a/tools/virtio/devices/net/virtio_net.c
+++ b/tools/virtio/devices/net/virtio_net.c
@@ -12,10 +12,6 @@
 #include "event_monitor.h"
 #include "log.h"
 
-// Max iov entries for a net descriptor chain.  Typical packets use 1-3
-// descriptors; 8 is ample for the stack-allocated iov buffer used with
-// process_descriptor_chain_buf().
-#define NET_IOV_MAX 8
 #include "virtio.h"
 #include <errno.h>
 #include <fcntl.h>
@@ -26,6 +22,7 @@
 #include <sys/ioctl.h>
 #include <sys/uio.h>
 #include <unistd.h>
+
 NetDev *init_net_dev(uint8_t mac[]) {
     NetDev *dev = malloc(sizeof(NetDev));
     dev->config.mac[0] = mac[0];
@@ -38,6 +35,8 @@ NetDev *init_net_dev(uint8_t mac[]) {
     dev->tapfd = -1;
     dev->rx_ready = 0;
     dev->event = NULL;
+    dev->in_iov = NULL;
+    dev->out_iov = NULL;
     return dev;
 }
 
@@ -94,7 +93,7 @@ void virtio_net_event_handler(int fd, int epoll_type, void *param) {
     VirtIODevice *vdev = param;
     NetDev *net = vdev->dev;
     VirtQueue *vq = &vdev->vqs[NET_QUEUE_RX];
-    int len;
+    ssize_t len;
     if (fd != net->tapfd || !(epoll_type & EPOLLIN)) {
         log_error("invalid event");
         return;
@@ -120,9 +119,8 @@ void virtio_net_event_handler(int fd, int epoll_type, void *param) {
     uint32_t batch_lens[VIRTQUEUE_NET_MAX_SIZE];
     int batch_count = 0;
     while (!virtqueue_is_empty(vq)) {
-        struct iovec in_buf[NET_IOV_MAX];
         struct VirtioBufConfig cfg = {
-            .in_iov = in_buf,
+            .in_iov = net->in_iov,
             .max_in = NET_IOV_MAX,
         };
         struct VirtioRequest req;
@@ -179,25 +177,21 @@ void virtio_net_event_handler(int fd, int epoll_type, void *param) {
 static void virtq_tx_handle_one_request(VirtIODevice *vdev, VirtQueue *vq,
                                         uint16_t *out_indices,
                                         uint32_t *out_lens, int *out_count) {
-    struct iovec out_buf[NET_IOV_MAX];
-    struct VirtioBufConfig cfg = {
-        .out_iov = out_buf,
-        .max_out = NET_IOV_MAX - 1,
-    };
-    struct VirtioRequest req;
-    int i, n, packet_len, all_len;
-    uint16_t idx = vq->avail_ring->ring[vq->last_avail_idx & (vq->num - 1)];
-    char pad[64] = {0};
-    ssize_t len;
     NetDev *net = vdev->dev;
-    size_t header_len = get_nethdr_size(vdev);
     if (net->tapfd == -1) {
         log_error("tap device is invalid");
         return;
     }
 
-    // NET_IOV_MAX - 1 reserves one slot for ethernet padding
-    n = process_descriptor_chain_buf(vq, idx, &cfg, &req);
+    size_t header_len = get_nethdr_size(vdev);
+    struct VirtioBufConfig cfg = {
+        .out_iov = net->out_iov,
+        .max_out = NET_IOV_MAX - 1,
+    };
+    struct VirtioRequest req;
+    uint16_t idx = vq->avail_ring->ring[vq->last_avail_idx & (vq->num - 1)];
+
+    int n = process_descriptor_chain_buf(vq, idx, &cfg, &req);
     if (n < 1) {
         return;
     }
@@ -211,19 +205,21 @@ static void virtq_tx_handle_one_request(VirtIODevice *vdev, VirtQueue *vq,
         return;
     }
 
-    for (i = 0, all_len = 0; i < req.out_count; i++)
+    size_t all_len = 0;
+    for (size_t i = 0; i < req.out_count; i++)
         all_len += req.out_iov[i].iov_len;
 
-    packet_len = all_len - header_len;
-    log_debug("packet send: %d bytes", packet_len);
+    size_t packet_len = all_len - header_len;
+    log_debug("packet send: %zu bytes", packet_len);
 
     // The mininum packet for data link layer is 64 bytes.
+    char pad[64] = {0};
     if (packet_len < 64) {
         req.out_iov[req.out_count].iov_base = pad;
         req.out_iov[req.out_count].iov_len = 64 - packet_len;
         req.out_count++;
     }
-    len = writev(net->tapfd, req.out_iov, req.out_count);
+    ssize_t len = writev(net->tapfd, req.out_iov, req.out_count);
     if (len < 0) {
         log_error("write tap failed, errno %d", errno);
     }
@@ -268,7 +264,7 @@ void net_on_status(VirtIODevice *vdev, uint32_t status) {
     // FEATURES_OK indicates guest has finished writing DRIVER_FEATURES.
     // Configure TAP virtio-net header size to match the negotiated format.
     if (status & VIRTIO_CONFIG_S_FEATURES_OK) {
-        int hdr_sz = get_nethdr_size(vdev);
+        int hdr_sz = (int)get_nethdr_size(vdev);
         if (ioctl(net->tapfd, TUNSETVNETHDRSZ, &hdr_sz) < 0)
             log_error("TUNSETVNETHDRSZ(%d) failed", hdr_sz);
     }
@@ -301,6 +297,18 @@ int virtio_net_init(VirtIODevice *vdev, char *devname) {
         net->tapfd = -1;
         return -1;
     }
+    net->in_iov = malloc(sizeof(struct iovec) * NET_IOV_MAX);
+    net->out_iov = malloc(sizeof(struct iovec) * NET_IOV_MAX);
+    if (!net->in_iov || !net->out_iov) {
+        log_error("failed to allocate iov buffers");
+        free(net->in_iov);
+        free(net->out_iov);
+        net->in_iov = NULL;
+        net->out_iov = NULL;
+        close(net->tapfd);
+        net->tapfd = -1;
+        return -1;
+    }
     vdev->status_changed = net_on_status;
     vdev->virtio_close = virtio_net_close;
     return 0;
@@ -310,6 +318,8 @@ void virtio_net_close(VirtIODevice *vdev) {
     NetDev *dev = vdev->dev;
     close(dev->tapfd);
     free(dev->event);
+    free(dev->in_iov);
+    free(dev->out_iov);
     free(dev);
     free(vdev->vqs);
     free(vdev);

--- a/tools/virtio/devices/net/virtio_net.c
+++ b/tools/virtio/devices/net/virtio_net.c
@@ -117,7 +117,7 @@ void virtio_net_event_handler(int fd, int epoll_type, void *param) {
     }
     uint16_t batch_indices[VIRTQUEUE_NET_MAX_SIZE];
     uint32_t batch_lens[VIRTQUEUE_NET_MAX_SIZE];
-    int batch_count = 0;
+    size_t batch_count = 0;
     while (!virtqueue_is_empty(vq)) {
         struct VirtioBufConfig cfg = {
             .in_iov = net->in_iov,
@@ -176,7 +176,7 @@ void virtio_net_event_handler(int fd, int epoll_type, void *param) {
 
 static void virtq_tx_handle_one_request(VirtIODevice *vdev, VirtQueue *vq,
                                         uint16_t *out_indices,
-                                        uint32_t *out_lens, int *out_count) {
+                                        uint32_t *out_lens, size_t *out_count) {
     NetDev *net = vdev->dev;
     if (net->tapfd == -1) {
         log_error("tap device is invalid");
@@ -233,7 +233,7 @@ int virtio_net_txq_notify_handler(VirtIODevice *vdev, VirtQueue *vq) {
     virtqueue_disable_notify(vq);
     uint16_t batch_indices[VIRTQUEUE_NET_MAX_SIZE];
     uint32_t batch_lens[VIRTQUEUE_NET_MAX_SIZE];
-    int batch_count = 0;
+    size_t batch_count = 0;
     for (;;) {
         while (!virtqueue_is_empty(vq)) {
             virtq_tx_handle_one_request(vdev, vq, batch_indices, batch_lens,

--- a/tools/virtio/devices/net/virtio_net.c
+++ b/tools/virtio/devices/net/virtio_net.c
@@ -53,7 +53,8 @@ static int open_tap(char *devname) {
     }
     memset(&ifr, 0, sizeof(ifr));
     // IFF_NO_PI tells kernel do not provide message header
-    ifr.ifr_flags = IFF_TAP | IFF_NO_PI;
+    // IFF_VNET_HDR enables virtio-net header passthrough with TAP
+    ifr.ifr_flags = IFF_TAP | IFF_NO_PI | IFF_VNET_HDR;
     strncpy(ifr.ifr_name, devname, IFNAMSIZ);
     ifr.ifr_name[IFNAMSIZ - 1] = '\0';
     if (ioctl(tunfd, TUNSETIFF, (void *)&ifr) < 0) {
@@ -77,26 +78,6 @@ int virtio_net_rxq_notify_handler(VirtIODevice *vdev, VirtQueue *vq) {
     }
     return 0;
 }
-/// remove the header in iov, return the new iov. the new iov num is in niov.
-static inline struct iovec *rm_iov_header(struct iovec *iov, int *niov,
-                                          int header_len) {
-    if (iov == NULL || *niov == 0 || iov[0].iov_len < (size_t)header_len) {
-        log_error("invalid iov");
-        return NULL;
-    }
-
-    iov[0].iov_len -= header_len;
-    if (iov[0].iov_len > 0) {
-        iov[0].iov_base = (char *)iov[0].iov_base + header_len;
-        return iov;
-    } else {
-        *niov = *niov - 1;
-        if (*niov == 0)
-            return NULL;
-        return iov + 1;
-    }
-}
-
 size_t get_nethdr_size(VirtIODevice *vdev) {
     // Virtio 1.0 specifies the header as NetHdr. But the legacy version
     // specifies the headr as NetHdrLegacy
@@ -111,12 +92,9 @@ size_t get_nethdr_size(VirtIODevice *vdev) {
 void virtio_net_event_handler(int fd, int epoll_type, void *param) {
     log_debug("virtio_net_event_handler");
     VirtIODevice *vdev = param;
-    void *vnet_header;
-    struct iovec *iov_packet;
     NetDev *net = vdev->dev;
     VirtQueue *vq = &vdev->vqs[NET_QUEUE_RX];
     int len;
-    size_t header_len = get_nethdr_size(vdev);
     if (fd != net->tapfd || !(epoll_type & EPOLLIN)) {
         log_error("invalid event");
         return;
@@ -161,16 +139,8 @@ void virtio_net_event_handler(int fd, int epoll_type, void *param) {
         }
 
         // RX: all buffers are VRING_DESC_F_WRITE → in_iov
-        vnet_header = req.in_iov[0].iov_base;
-        iov_packet = rm_iov_header(req.in_iov, &req.in_count, header_len);
-        if (iov_packet == NULL) {
-            batch_indices[batch_count] = idx;
-            batch_lens[batch_count] = 0;
-            batch_count++;
-            break;
-        }
-        // Read a packet from tap device
-        len = readv(net->tapfd, iov_packet, req.in_count);
+        // IFF_VNET_HDR: TAP writes [virtio_net_hdr | packet] directly
+        len = readv(net->tapfd, req.in_iov, req.in_count);
 
         if (len < 0 && errno == EWOULDBLOCK) {
             // No more packets from tapfd, restore last_avail_idx.
@@ -196,13 +166,8 @@ void virtio_net_event_handler(int fd, int epoll_type, void *param) {
             break;
         }
 
-        memset(vnet_header, 0, header_len);
-        if (vdev->regs.drv_feature & (1ULL << VIRTIO_F_VERSION_1)) {
-            ((NetHdr *)vnet_header)->num_buffers = 1;
-        }
-
         batch_indices[batch_count] = idx;
-        batch_lens[batch_count] = len + header_len;
+        batch_lens[batch_count] = len;
         batch_count++;
     }
 
@@ -250,8 +215,6 @@ static void virtq_tx_handle_one_request(VirtIODevice *vdev, VirtQueue *vq,
         all_len += req.out_iov[i].iov_len;
 
     packet_len = all_len - header_len;
-    req.out_iov[0].iov_base += header_len;
-    req.out_iov[0].iov_len -= header_len;
     log_debug("packet send: %d bytes", packet_len);
 
     // The mininum packet for data link layer is 64 bytes.
@@ -299,6 +262,22 @@ int virtio_net_txq_notify_handler(VirtIODevice *vdev, VirtQueue *vq) {
     return 0;
 }
 
+void net_on_status(VirtIODevice *vdev, uint32_t status) {
+    NetDev *net = vdev->dev;
+
+    // FEATURES_OK indicates guest has finished writing DRIVER_FEATURES.
+    // Configure TAP virtio-net header size to match the negotiated format.
+    if (status & VIRTIO_CONFIG_S_FEATURES_OK) {
+        int hdr_sz = get_nethdr_size(vdev);
+        if (ioctl(net->tapfd, TUNSETVNETHDRSZ, &hdr_sz) < 0)
+            log_error("TUNSETVNETHDRSZ(%d) failed", hdr_sz);
+    }
+
+    if (status == 0) {
+        net->rx_ready = 0;
+    }
+}
+
 int virtio_net_init(VirtIODevice *vdev, char *devname) {
     log_info("virtio net init");
     NetDev *net = vdev->dev;
@@ -322,6 +301,7 @@ int virtio_net_init(VirtIODevice *vdev, char *devname) {
         net->tapfd = -1;
         return -1;
     }
+    vdev->status_changed = net_on_status;
     vdev->virtio_close = virtio_net_close;
     return 0;
 }

--- a/tools/virtio/include/virtio.h
+++ b/tools/virtio/include/virtio.h
@@ -218,6 +218,11 @@ int process_descriptor_chain_buf(VirtQueue *vq, uint16_t descriptor_head,
 
 void update_used_ring(VirtQueue *vq, uint16_t idx, uint32_t iolen);
 
+// Batch version of update_used_ring: writes `count` used-ring entries
+// with a single pair of write barriers instead of two per entry.
+void update_used_ring_batch(VirtQueue *vq, const uint16_t *indices,
+                            const uint32_t *lens, int count);
+
 uint64_t virtio_mmio_read(VirtIODevice *vdev, uint64_t offset, unsigned size);
 
 void virtio_mmio_write(VirtIODevice *vdev, uint64_t offset, uint64_t value,

--- a/tools/virtio/include/virtio.h
+++ b/tools/virtio/include/virtio.h
@@ -190,6 +190,32 @@ int process_descriptor_chain(VirtQueue *vq, uint16_t *desc_idx,
                              struct iovec **iov, uint16_t **flags,
                              int append_len, bool copy_flags);
 
+// Caller-provided buffer arrays for process_descriptor_chain_buf().
+// out_iov / in_iov point to the arrays; max_out / max_in are their capacities.
+struct VirtioBufConfig {
+    struct iovec *out_iov;
+    size_t max_out;
+    struct iovec *in_iov;
+    size_t max_in;
+};
+
+// Parsed descriptor chain split by direction.  iov pointers alias the
+// caller-provided buffers in VirtioBufConfig; counts are the number
+// of populated entries.
+struct VirtioRequest {
+    struct iovec *out_iov;
+    unsigned int out_count;
+    struct iovec *in_iov;
+    unsigned int in_count;
+};
+
+// Fill req from the descriptor chain starting at desc_head into the
+// buffers described by cfg.  Returns total chain_len (out_count +
+// in_count) on success, -1 if either buffer is too small.
+int process_descriptor_chain_buf(VirtQueue *vq, uint16_t descriptor_head,
+                                 const struct VirtioBufConfig *cfg,
+                                 struct VirtioRequest *req);
+
 void update_used_ring(VirtQueue *vq, uint16_t idx, uint32_t iolen);
 
 uint64_t virtio_mmio_read(VirtIODevice *vdev, uint64_t offset, unsigned size);

--- a/tools/virtio/include/virtio.h
+++ b/tools/virtio/include/virtio.h
@@ -127,7 +127,9 @@ struct VirtIODevice {
               // is ConsoleDev Pointer to the specific device's special config
     void (*virtio_close)(
         VirtIODevice *vdev); // Function called when closing the virtio device
-    bool activated;          // Whether the current virtio device is activated
+    void (*status_changed)(VirtIODevice *vdev,
+                           uint32_t status); // Called on STATUS register write
+    bool activated; // Whether the current virtio device is activated
 };
 
 // used event idx for driver telling device when to notify driver.

--- a/tools/virtio/include/virtio.h
+++ b/tools/virtio/include/virtio.h
@@ -223,7 +223,7 @@ void update_used_ring(VirtQueue *vq, uint16_t idx, uint32_t iolen);
 // Batch version of update_used_ring: writes `count` used-ring entries
 // with a single pair of write barriers instead of two per entry.
 void update_used_ring_batch(VirtQueue *vq, const uint16_t *indices,
-                            const uint32_t *lens, int count);
+                            const uint32_t *lens, size_t count);
 
 uint64_t virtio_mmio_read(VirtIODevice *vdev, uint64_t offset, unsigned size);
 

--- a/tools/virtio/include/virtio_net.h
+++ b/tools/virtio/include/virtio_net.h
@@ -46,4 +46,5 @@ int virtio_net_txq_notify_handler(VirtIODevice *vdev, VirtQueue *vq);
 void virtio_net_event_handler(int fd, int epoll_type, void *param);
 int virtio_net_init(VirtIODevice *vdev, char *devname);
 void virtio_net_close(VirtIODevice *vdev);
+void net_on_status(VirtIODevice *vdev, uint32_t status);
 #endif //_HVISOR_VIRTIO_NET_H

--- a/tools/virtio/include/virtio_net.h
+++ b/tools/virtio/include/virtio_net.h
@@ -22,6 +22,14 @@
 #define NET_MAX_QUEUES 2
 
 #define VIRTQUEUE_NET_MAX_SIZE 256
+
+// Max iov entries for a single descriptor chain.  Each descriptor in the
+// chain contributes at most one iov entry, and a chain can never exceed
+// the total queue size (a single descriptor's next field cannot wrap past
+// vq->num due to the loop guard in process_descriptor_chain_buf).  So
+// VIRTQUEUE_NET_MAX_SIZE is the tight upper bound.
+#define NET_IOV_MAX VIRTQUEUE_NET_MAX_SIZE
+
 // VIRTIO_RING_F_INDIRECT_DESC and VIRTIO_RING_F_EVENT_IDX are supported, for
 // some reason we cancel them.
 #define NET_SUPPORTED_FEATURES                                                 \
@@ -36,6 +44,8 @@ typedef struct virtio_net_dev {
     int tapfd;
     int rx_ready;
     struct hvisor_event *event;
+    struct iovec *in_iov;
+    struct iovec *out_iov;
 } NetDev;
 
 NetDev *init_net_dev(uint8_t mac[]);

--- a/tools/virtio/virtio.c
+++ b/tools/virtio/virtio.c
@@ -486,6 +486,110 @@ inline int descriptor2iov(int i, volatile VirtqDesc *vd, struct iovec *iov,
     return 0;
 }
 
+// Dispatch a descriptor into cfg->out_iov or cfg->in_iov based on flags.
+static inline int push_descriptor(uint16_t flags, void *address,
+                                  uint32_t length,
+                                  const struct VirtioBufConfig *cfg,
+                                  size_t *out_count, size_t *in_count) {
+    struct iovec *buffer;
+    size_t max;
+    size_t *count;
+
+    if (flags & VRING_DESC_F_WRITE) {
+        buffer = cfg->in_iov;
+        max = cfg->max_in;
+        count = in_count;
+    } else {
+        buffer = cfg->out_iov;
+        max = cfg->max_out;
+        count = out_count;
+    }
+
+    if (*count >= max)
+        return -1;
+
+    buffer[*count].iov_base = address;
+    buffer[*count].iov_len = length;
+    (*count)++;
+    return 0;
+}
+
+/// record one descriptor list to iov, caller-provided buffer (no malloc)
+int process_descriptor_chain_buf(VirtQueue *virtqueue, uint16_t descriptor_head,
+                                 const struct VirtioBufConfig *cfg,
+                                 struct VirtioRequest *req) {
+
+    // Single-pass traversal; virtqueue->num guards against circular chains.
+    size_t out_count = 0, in_count = 0;
+    uint16_t next = descriptor_head;
+    volatile VirtqDesc *descriptor_table = virtqueue->desc_table;
+    for (size_t iter = 0; iter < virtqueue->num; iter++) {
+        VirtqDesc descriptor = descriptor_table[next];
+
+        if (descriptor.flags & VRING_DESC_F_INDIRECT) {
+            const size_t indirect_count = descriptor.len / sizeof(VirtqDesc);
+
+            volatile VirtqDesc *indirect_table = get_virt_addr(
+                (void *)(uintptr_t)descriptor.addr, virtqueue->dev->zone_id);
+            uint16_t indirect_next = 0;
+            for (size_t j = 0; j < indirect_count; j++) {
+                if (indirect_next >= indirect_count) {
+                    log_error("indirect_next is not less than indirect_count: "
+                              "%zu >= %zu",
+                              indirect_next, indirect_count);
+                    return -1;
+                }
+
+                VirtqDesc indirect_descriptor = indirect_table[indirect_next];
+                void *address =
+                    get_virt_addr((void *)(uintptr_t)indirect_descriptor.addr,
+                                  virtqueue->dev->zone_id);
+                if (!address) {
+                    log_error("address is null");
+                    return -1;
+                }
+
+                if (push_descriptor(indirect_descriptor.flags, address,
+                                    indirect_descriptor.len, cfg, &out_count,
+                                    &in_count) < 0) {
+                    log_error("descriptor buffer overflow");
+                    return -1;
+                }
+                if (!(indirect_descriptor.flags & VRING_DESC_F_NEXT))
+                    break;
+                indirect_next = indirect_descriptor.next;
+            }
+        } else {
+            void *address = get_virt_addr((void *)(uintptr_t)descriptor.addr,
+                                          virtqueue->dev->zone_id);
+            if (!address) {
+                log_error("address is null");
+                return -1;
+            }
+
+            if (push_descriptor(descriptor.flags, address, descriptor.len, cfg,
+                                &out_count, &in_count) < 0) {
+                log_error("descriptor buffer overflow");
+                return -1;
+            }
+        }
+
+        if (!(descriptor.flags & VRING_DESC_F_NEXT))
+            break;
+        next = descriptor.next;
+    }
+
+    *req = (struct VirtioRequest){
+        .out_iov = cfg->out_iov,
+        .out_count = out_count,
+        .in_iov = cfg->in_iov,
+        .in_count = in_count,
+    };
+
+    virtqueue->last_avail_idx++;
+    return out_count + in_count;
+}
+
 /// record one descriptor list to iov
 /// \param desc_idx the first descriptor's idx in descriptor list.
 /// \param iov the iov to record

--- a/tools/virtio/virtio.c
+++ b/tools/virtio/virtio.c
@@ -441,7 +441,7 @@ void virtqueue_enable_notify(VirtQueue *vq) {
     if (vq->event_idx_enabled) {
         VQ_AVAIL_EVENT(vq) = vq->avail_ring->idx;
     } else {
-        vq->used_ring->flags &= !(uint16_t)VRING_USED_F_NO_NOTIFY;
+        vq->used_ring->flags &= ~(uint16_t)VRING_USED_F_NO_NOTIFY;
     }
     write_barrier();
 }

--- a/tools/virtio/virtio.c
+++ b/tools/virtio/virtio.c
@@ -705,6 +705,32 @@ void update_used_ring(VirtQueue *vq, uint16_t idx, uint32_t iolen) {
         used_idx, idx, vq->num);
 }
 
+void update_used_ring_batch(VirtQueue *vq, const uint16_t *indices,
+                            const uint32_t *lens, int count) {
+    volatile VirtqUsed *used_ring;
+    uint16_t used_idx, mask;
+
+    if (count <= 0)
+        return;
+
+    // Ensure prior stores (e.g. readv into guest buffers) are globally
+    // visible before any used-ring entry becomes observable.
+    write_barrier();
+
+    used_ring = vq->used_ring;
+    used_idx = used_ring->idx;
+    mask = vq->num - 1;
+
+    for (int i = 0; i < count; i++) {
+        used_ring->ring[(used_idx + i) & mask].id = indices[i];
+        used_ring->ring[(used_idx + i) & mask].len = lens[i];
+    }
+
+    write_barrier(); // make all entries visible
+    used_ring->idx = used_idx + count;
+    write_barrier(); // make idx update visible
+}
+
 // function for translating virtio offset to meaning string
 static const char *virtio_mmio_reg_name(uint64_t offset) {
     switch (offset) {

--- a/tools/virtio/virtio.c
+++ b/tools/virtio/virtio.c
@@ -706,11 +706,11 @@ void update_used_ring(VirtQueue *vq, uint16_t idx, uint32_t iolen) {
 }
 
 void update_used_ring_batch(VirtQueue *vq, const uint16_t *indices,
-                            const uint32_t *lens, int count) {
+                            const uint32_t *lens, size_t count) {
     volatile VirtqUsed *used_ring;
     uint16_t used_idx, mask;
 
-    if (count <= 0)
+    if (count == 0)
         return;
 
     // Ensure prior stores (e.g. readv into guest buffers) are globally
@@ -721,7 +721,7 @@ void update_used_ring_batch(VirtQueue *vq, const uint16_t *indices,
     used_idx = used_ring->idx;
     mask = vq->num - 1;
 
-    for (int i = 0; i < count; i++) {
+    for (size_t i = 0; i < count; i++) {
         used_ring->ring[(used_idx + i) & mask].id = indices[i];
         used_ring->ring[(used_idx + i) & mask].len = lens[i];
     }

--- a/tools/virtio/virtio.c
+++ b/tools/virtio/virtio.c
@@ -1007,6 +1007,8 @@ void virtio_mmio_write(VirtIODevice *vdev, uint64_t offset, uint64_t value,
         if (regs->status == 0) {
             virtio_dev_reset(vdev);
         }
+        if (vdev->status_changed)
+            vdev->status_changed(vdev, value);
         break;
     case VIRTIO_MMIO_QUEUE_DESC_LOW:
         log_debug("write VIRTIO_MMIO_QUEUE_DESC_LOW");


### PR DESCRIPTION
Two virtio-net TX correctness bugs fixed:

- **Re-check avail ring after `virtqueue_enable_notify`**: the guest may add TX descriptors during the `VRING_USED_F_NO_NOTIFY` window. Without a re-check those descriptors are lost.
- **Inject IRQ after TX used-ring update**: UDP has no implicit polling (unlike TCP which polls via ACK processing). Without an IRQ the guest never recycles completed TX descriptors, deadlocking `sendto()`.

Also included are per-packet CPU optimizations (`process_descriptor_chain_buf` replaces per-packet `malloc`/`free`, `update_used_ring_batch` amortises DMB overhead) and six standalone bug fixes.

## Test results

RK3588, zone1 (`192.168.255.3/24`) <-> root-linux (`192.168.255.2/24`), iperf3 60s:

```bash
iperf3 -i 10 -c 192.168.255.2 -t 60 --bidir           # TCP
iperf3 -i 10 -c 192.168.255.2 -t 60 -u -b 10G         # UDP TX
iperf3 -i 10 -c 192.168.255.2 -t 60 -u -b 10G -R      # UDP RX
```

| Test | Metric | Before | After |
|:-:|:-:|:-:|:-:|
| TCP bidir TX | Gbps | 0.51 | **1.11** |
| TCP bidir RX | Gbps | 0.13 | **0.21** |
| UDP TX | Gbps | 0.0008 (broken) | **2.28** |
| UDP `-R` RX | Gbps | 0.24 | 0.27 |

UDP TX and TCP throughput is improved.

## References

Related issue #101.

Partially-fixes [hvisor #240](https://github.com/syswonder/hvisor/issues/240).
