### PR TITLE
virtio: support dynamic device add

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -112,6 +112,16 @@ nohup ./hvisor virtio start virtio_cfg.json &
 ./hvisor zone start <vm_config.json>
 ```
 
+守护进程启动后，也支持继续向运行中的后端添加 Virtio 设备。后续配置可以通过以下命令发送给已经运行的守护进程：
+
+```bash
+./hvisor virtio add virtio_zone2.json
+./hvisor zone start zone2_linux.json
+```
+
+`virtio start` 会创建本地 Unix domain socket：`/run/hvisor-virtio.sock`。
+`virtio add` 会连接该 socket，并请求运行中的守护进程解析新的 Virtio 配置、在需要时映射 zone 内存、发布配置中启用的设备。原有带顶层 `zones` 数组的完整 `virtio_cfg.json` 仍然兼容。对于 MMIO Virtio 设备，建议先执行 `virtio add`，再启动将使用这些设备的 zone，这样 zone 配置仍可由 hvisor 注册对应的 Virtio MMIO 区域。
+
 其中 `&` 说明该命令会在后台运行。由于 Virtio 守护进程使用 `syslog` 记录日志，使用以下命令查看 `hvisor-tool` 的日志：
 
 *   **对于使用 `systemd` 的系统：**

--- a/README.md
+++ b/README.md
@@ -112,6 +112,23 @@ nohup ./hvisor virtio start virtio_cfg.json &
 ./hvisor zone start <vm_config.json>
 ```
 
+The daemon also supports adding Virtio devices after it has started. A later
+configuration can be sent to the running daemon with:
+
+```bash
+./hvisor virtio add virtio_zone2.json
+./hvisor zone start zone2_linux.json
+```
+
+`virtio start` creates a local Unix domain socket at
+`/run/hvisor-virtio.sock`. `virtio add` connects to that socket and asks the
+running daemon to parse the new Virtio configuration, map the zone memory if it
+has not been mapped yet, and publish the enabled devices. Existing full
+`virtio_cfg.json` files with a top-level `zones` array are still supported.
+For MMIO Virtio devices, run `virtio add` before starting the zone that will use
+those devices, so the zone configuration can still register the corresponding
+Virtio MMIO regions with hvisor.
+
 The `&` part indicates that this command will run in the background. Since the Virtio daemon uses `syslog` for logging, use the following commands to view the `hvisor-tool` logs:
 
 *   **For systems with `systemd`:**
@@ -153,4 +170,4 @@ To shut down the Virtio daemon and all the created devices, execute the followin
 
 ```
 pkill hvisor-virtio
-``` 
+```

--- a/tools/hvisor.c
+++ b/tools/hvisor.c
@@ -39,7 +39,8 @@ static void __attribute__((noreturn)) help(int exit_status) {
     printf("  zone start    <config.json>    Initialize an isolation zone\n");
     printf("  zone shutdown -id <zone_id>   Terminate a zone by ID\n");
     printf("  zone list                      List all active zones\n");
-    printf("  virtio start  <virtio.json>    Activate virtio devices\n\n");
+    printf("  virtio start  <virtio.json>    Activate virtio devices\n");
+    printf("  virtio add    <virtio.json>    Add virtio devices to daemon\n\n");
     printf("Options:\n");
     printf("  --id <zone_id>    Specify zone ID for shutdown\n");
     printf("  --help            Show this help message\n\n");
@@ -1044,6 +1045,8 @@ int main(int argc, char *argv[]) {
 
         if (strcmp(argv[2], "start") == 0) {
             err = virtio_start(argc, argv);
+        } else if (strcmp(argv[2], "add") == 0) {
+            err = virtio_add(argc, argv);
         } else {
             help(1);
         }

--- a/tools/hvisor.c
+++ b/tools/hvisor.c
@@ -623,20 +623,13 @@ static int parse_pci_config(cJSON *root, zone_config_t *config) {
         cJSON *dev_function_json =
             SAFE_CJSON_GET_OBJECT_ITEM(dev_config_json, "function");
         cJSON *dev_vbus_json =
-            cJSON_GetObjectItemCaseSensitive(dev_config_json, "v_bus");
+            SAFE_CJSON_GET_OBJECT_ITEM(dev_config_json, "v_bus");
         cJSON *dev_vdevice_json =
-            cJSON_GetObjectItemCaseSensitive(dev_config_json, "v_device");
+            SAFE_CJSON_GET_OBJECT_ITEM(dev_config_json, "v_device");
         cJSON *dev_vfunction_json =
-            cJSON_GetObjectItemCaseSensitive(dev_config_json, "v_function");
+            SAFE_CJSON_GET_OBJECT_ITEM(dev_config_json, "v_function");
         cJSON *dev_type_json =
             SAFE_CJSON_GET_OBJECT_ITEM(dev_config_json, "dev_type");
-
-        if (!dev_vbus_json)
-            dev_vbus_json = dev_bus_json;
-        if (!dev_vdevice_json)
-            dev_vdevice_json = dev_device_json;
-        if (!dev_vfunction_json)
-            dev_vfunction_json = dev_function_json;
 
         if (parse_json_linux_u8(dev_domain_json, &dev_config->domain) != 0 ||
             parse_json_linux_u8(dev_bus_json, &dev_config->bus) != 0 ||

--- a/tools/virtio/devices/blk/virtio_blk.c
+++ b/tools/virtio/devices/blk/virtio_blk.c
@@ -155,6 +155,7 @@ BlkDev *init_blk_dev(VirtIODevice *vdev) {
     return dev;
 }
 
+// Start the worker only after the backing image is opened successfully.
 int start_blk_worker(VirtIODevice *vdev) {
     if (!vdev || !vdev->dev) {
         log_error("invalid blk device");
@@ -193,8 +194,8 @@ int virtio_blk_init(VirtIODevice *vdev, const char *img_path) {
     dev->config.size_max = blk_size;
     dev->img_fd = img_fd;
     vdev->virtio_close = virtio_blk_close;
-    log_info("debug: virtio_blk_init: %s, size is %lld", img_path,
-             dev->config.capacity);
+    log_debug("virtio_blk_init: %s, size is %lld", img_path,
+              dev->config.capacity);
     return 0;
 }
 

--- a/tools/virtio/devices/blk/virtio_blk.c
+++ b/tools/virtio/devices/blk/virtio_blk.c
@@ -123,7 +123,12 @@ static void *blkproc_thread(void *arg) {
 
 // create blk dev.
 BlkDev *init_blk_dev(VirtIODevice *vdev) {
-    BlkDev *dev = malloc(sizeof(BlkDev));
+    BlkDev *dev = calloc(1, sizeof(BlkDev));
+    if (!dev) {
+        log_error("failed to allocate blk device");
+        return NULL;
+    }
+
     vdev->dev = dev;
     dev->config.capacity = -1;
     dev->config.size_max = -1;
@@ -131,10 +136,31 @@ BlkDev *init_blk_dev(VirtIODevice *vdev) {
     dev->img_fd = -1;
     dev->close = 0;
     // TODO: chang to thread poll
-    pthread_mutex_init(&dev->mtx, NULL);
-    pthread_cond_init(&dev->cond, NULL);
+    if (pthread_mutex_init(&dev->mtx, NULL) != 0) {
+        log_error("failed to init blk mutex");
+        free(dev);
+        vdev->dev = NULL;
+        return NULL;
+    }
+    dev->mutex_initialized = true;
+    if (pthread_cond_init(&dev->cond, NULL) != 0) {
+        log_error("failed to init blk cond");
+        pthread_mutex_destroy(&dev->mtx);
+        free(dev);
+        vdev->dev = NULL;
+        return NULL;
+    }
+    dev->cond_initialized = true;
     TAILQ_INIT(&dev->procq);
-    pthread_create(&dev->tid, NULL, blkproc_thread, vdev);
+    if (pthread_create(&dev->tid, NULL, blkproc_thread, vdev) != 0) {
+        log_error("failed to create blk thread");
+        pthread_cond_destroy(&dev->cond);
+        pthread_mutex_destroy(&dev->mtx);
+        free(dev);
+        vdev->dev = NULL;
+        return NULL;
+    }
+    dev->thread_started = true;
     return dev;
 }
 
@@ -145,7 +171,6 @@ int virtio_blk_init(VirtIODevice *vdev, const char *img_path) {
     uint64_t blk_size;
     if (img_fd == -1) {
         log_error("cannot open %s, Error code is %d", img_path, errno);
-        close(img_fd);
         return -1;
     }
     if (fstat(img_fd, &st) == -1) {
@@ -246,16 +271,28 @@ int virtio_blk_notify_handler(VirtIODevice *vdev, VirtQueue *vq) {
 }
 
 void virtio_blk_close(VirtIODevice *vdev) {
+    if (!vdev)
+        return;
+
     BlkDev *dev = vdev->dev;
-    pthread_mutex_lock(&dev->mtx);
-    dev->close = 1;
-    pthread_cond_signal(&dev->cond);
-    pthread_mutex_unlock(&dev->mtx);
-    pthread_join(dev->tid, NULL);
-    pthread_mutex_destroy(&dev->mtx);
-    pthread_cond_destroy(&dev->cond);
-    close(dev->img_fd);
-    free(dev);
+    if (dev) {
+        if (dev->thread_started && dev->mutex_initialized &&
+            dev->cond_initialized) {
+            pthread_mutex_lock(&dev->mtx);
+            dev->close = 1;
+            pthread_cond_signal(&dev->cond);
+            pthread_mutex_unlock(&dev->mtx);
+            pthread_join(dev->tid, NULL);
+        }
+        if (dev->mutex_initialized)
+            pthread_mutex_destroy(&dev->mtx);
+        if (dev->cond_initialized)
+            pthread_cond_destroy(&dev->cond);
+        if (dev->img_fd >= 0)
+            close(dev->img_fd);
+        dev->img_fd = -1;
+        free(dev);
+    }
     free(vdev->vqs);
     free(vdev);
 }

--- a/tools/virtio/devices/console/virtio_console.c
+++ b/tools/virtio/devices/console/virtio_console.c
@@ -25,6 +25,11 @@ static uint8_t trashbuf[1024];
 
 ConsoleDev *init_console_dev() {
     ConsoleDev *dev = (ConsoleDev *)malloc(sizeof(ConsoleDev));
+    if (!dev) {
+        log_error("failed to allocate console device");
+        return NULL;
+    }
+
     dev->config.cols = 80;
     dev->config.rows = 25;
     dev->master_fd = -1;
@@ -96,18 +101,26 @@ int virtio_console_init(VirtIODevice *vdev) {
     master_fd = posix_openpt(O_RDWR | O_NOCTTY);
     if (master_fd < 0) {
         log_error("Failed to open master pty, errno is %d", errno);
+        return -1;
     }
     if (grantpt(master_fd) < 0) {
         log_error("Failed to grant pty, errno is %d", errno);
+        close(master_fd);
+        return -1;
     }
     if (unlockpt(master_fd) < 0) {
         log_error("Failed to unlock pty, errno is %d", errno);
+        close(master_fd);
+        return -1;
     }
     dev->master_fd = master_fd;
 
     slave_name = ptsname(master_fd);
     if (slave_name == NULL) {
         log_error("Failed to get slave name, errno is %d", errno);
+        close(master_fd);
+        dev->master_fd = -1;
+        return -1;
     }
     log_info("char device redirected to %s", slave_name);
     // Open and keep a slave fd in this process. Without a slave peer,
@@ -143,7 +156,7 @@ int virtio_console_init(VirtIODevice *vdev) {
 
     if (dev->event == NULL) {
         log_error("Can't register console event");
-        close(master_fd);
+        close(dev->master_fd);
         if (dev->slave_keepalive_fd >= 0) {
             close(dev->slave_keepalive_fd);
             dev->slave_keepalive_fd = -1;
@@ -204,13 +217,23 @@ int virtio_console_txq_notify_handler(VirtIODevice *vdev, VirtQueue *vq) {
 }
 
 void virtio_console_close(VirtIODevice *vdev) {
+    if (!vdev)
+        return;
+
     ConsoleDev *dev = vdev->dev;
-    close(dev->master_fd);
-    if (dev->slave_keepalive_fd >= 0) {
-        close(dev->slave_keepalive_fd);
+    if (dev) {
+        if (dev->event) {
+            remove_event(dev->event);
+            dev->event = NULL;
+        }
+        if (dev->master_fd >= 0)
+            close(dev->master_fd);
+        dev->master_fd = -1;
+        if (dev->slave_keepalive_fd >= 0)
+            close(dev->slave_keepalive_fd);
+        dev->slave_keepalive_fd = -1;
+        free(dev);
     }
-    free(dev->event);
-    free(dev);
     free(vdev->vqs);
     free(vdev);
 }

--- a/tools/virtio/devices/gpu/virtio_gpu.c
+++ b/tools/virtio/devices/gpu/virtio_gpu.c
@@ -338,6 +338,8 @@ void virtio_gpu_create_drm_framebuffer(GPUScanout *scanout, uint32_t *error) {
         *error = VIRTIO_GPU_RESP_ERR_UNSPEC;
         return;
     } // Create a dumb object
+    fb->drm_dumb_handle = dumb.handle;
+    fb->drm_dumb_size = dumb.size;
 
     map.handle = dumb.handle;
     // Bind the video memory to the framebuffer, get the offset based on the
@@ -368,9 +370,11 @@ void virtio_gpu_create_drm_framebuffer(GPUScanout *scanout, uint32_t *error) {
     if (drmModeAddFB(scanout->card0_fd, dumb.width, dumb.height, 24, 32,
                      dumb.pitch, dumb.handle, &fb_id) < 0) {
         log_error("%s failed to add a drm_framebuffer to card0", __func__);
+        virtio_gpu_remove_drm_framebuffer(scanout);
         *error = VIRTIO_GPU_RESP_ERR_UNSPEC;
         return;
     }
+    fb->fb_id = fb_id;
 
     ///
     log_debug("%s create a drm_framebuffer with width: %d, height: %d, "
@@ -382,7 +386,7 @@ void virtio_gpu_create_drm_framebuffer(GPUScanout *scanout, uint32_t *error) {
     void *vaddr = mmap(0, dumb.size, PROT_READ | PROT_WRITE, MAP_SHARED,
                        scanout->card0_fd, map.offset);
 
-    if (!vaddr) {
+    if (vaddr == MAP_FAILED) {
         log_error("%s cannot map drm_framebuffer of scanout", __func__);
         virtio_gpu_remove_drm_framebuffer(scanout);
         *error = VIRTIO_GPU_RESP_ERR_UNSPEC;
@@ -392,9 +396,6 @@ void virtio_gpu_create_drm_framebuffer(GPUScanout *scanout, uint32_t *error) {
     log_debug("%s map drm_framebuffer to %x with size %d", __func__, vaddr,
               dumb.size);
 
-    fb->fb_id = fb_id;
-    fb->drm_dumb_handle = dumb.handle;
-    fb->drm_dumb_size = dumb.size;
     fb->fb_addr = vaddr;
     fb->enabled = true;
 }
@@ -469,19 +470,21 @@ void virtio_gpu_copy_and_flush(GPUScanout *scanout, GPUSimpleResource *res,
 void virtio_gpu_remove_drm_framebuffer(GPUScanout *scanout) {
     GPUFrameBuffer *fb = &scanout->frame_buffer;
 
-    if (!fb || !fb->enabled || !fb->fb_addr) {
-        log_error("%s found drm_framebuffer is not enabled yet");
+    if (!fb ||
+        (!fb->enabled && !fb->fb_id && !fb->drm_dumb_handle && !fb->fb_addr)) {
         return;
     }
 
     struct drm_mode_destroy_dumb destory = {0};
     destory.handle = fb->drm_dumb_handle;
 
-    drmModeRmFB(scanout->card0_fd, fb->fb_id);
-    if (fb->fb_addr != NULL) {
+    if (scanout->card0_fd >= 0 && fb->fb_id)
+        drmModeRmFB(scanout->card0_fd, fb->fb_id);
+    if (fb->fb_addr != NULL && fb->fb_addr != MAP_FAILED) {
         munmap(fb->fb_addr, fb->drm_dumb_size);
     }
-    drmIoctl(scanout->card0_fd, DRM_IOCTL_MODE_DESTROY_DUMB, &destory);
+    if (scanout->card0_fd >= 0 && fb->drm_dumb_handle)
+        drmIoctl(scanout->card0_fd, DRM_IOCTL_MODE_DESTROY_DUMB, &destory);
 
     log_debug("%s destoryed drm_framebuffer with id: %d, handle: %d, size: %d",
               __func__, fb->fb_id, fb->drm_dumb_handle, fb->drm_dumb_size);

--- a/tools/virtio/devices/gpu/virtio_gpu_base.c
+++ b/tools/virtio/devices/gpu/virtio_gpu_base.c
@@ -108,12 +108,13 @@ int virtio_gpu_init(VirtIODevice *vdev) {
         return -1;
     }
 
+    gdev->scanouts[0].card0_fd = drm_fd;
+
     // Get drm resources
     // Need to get the connector, CRTC, encoder, framebuffer of the device
     drmModeRes *res = drmModeGetResources(drm_fd);
     if (!res) {
         log_error("%s cannot get card0 resource", __func__);
-        close(drm_fd);
         return -1;
     }
 
@@ -121,45 +122,43 @@ int virtio_gpu_init(VirtIODevice *vdev) {
     drmModeConnector *connector = NULL;
     for (int i = 0; i < res->count_connectors; ++i) {
         connector = drmModeGetConnector(drm_fd, res->connectors[i]);
+        if (!connector)
+            continue;
         if (connector->connection == DRM_MODE_CONNECTED) {
             break;
         }
         drmModeFreeConnector(connector);
+        connector = NULL;
     }
 
-    if (!connector || connector->connection != DRM_MODE_CONNECTED) {
+    if (!connector || connector->connection != DRM_MODE_CONNECTED ||
+        connector->count_modes <= 0) {
         log_error("%s cannot find a connector", __func__);
         drmModeFreeResources(res);
-        close(drm_fd);
         return -1;
     }
+    gdev->scanouts[0].connector = connector;
 
     // Get encoder
     drmModeEncoder *encoder = drmModeGetEncoder(drm_fd, connector->encoder_id);
     if (!encoder) {
         log_error("%s cannot get encoder", __func__);
-        drmModeFreeConnector(connector);
         drmModeFreeResources(res);
-        close(drm_fd);
         return -1;
     }
+    gdev->scanouts[0].encoder = encoder;
 
     // Get CRTC
     drmModeCrtc *crtc = drmModeGetCrtc(drm_fd, encoder->crtc_id);
     if (!crtc) {
         log_error("%s cannot get CRTC", __func__);
-        drmModeFreeEncoder(encoder);
-        drmModeFreeConnector(connector);
         drmModeFreeResources(res);
-        close(drm_fd);
         return -1;
     }
     // drmModeModeInfo mode = connector->modes[0];
 
-    gdev->scanouts[0].card0_fd = drm_fd;
     gdev->scanouts[0].crtc = crtc;
-    gdev->scanouts[0].connector = connector;
-    gdev->scanouts[0].encoder = encoder;
+    drmModeFreeResources(res);
 
     ///
     log_debug("%s set scanout[0] card0_fd %d", __func__, drm_fd);
@@ -177,30 +176,73 @@ int virtio_gpu_init(VirtIODevice *vdev) {
     gdev->scanouts[0].height = connector->modes[0].vdisplay;
 
     // async
-    pthread_create(&gdev->gpu_thread, NULL, virtio_gpu_handler, vdev);
-    pthread_cond_init(&gdev->gpu_cond, NULL);
-    pthread_mutex_init(&gdev->queue_mutex, NULL);
+    if (pthread_cond_init(&gdev->gpu_cond, NULL) != 0) {
+        log_error("%s failed to initialize gpu cond", __func__);
+        return -1;
+    }
+    gdev->cond_initialized = true;
+    if (pthread_mutex_init(&gdev->queue_mutex, NULL) != 0) {
+        log_error("%s failed to initialize gpu mutex", __func__);
+        pthread_cond_destroy(&gdev->gpu_cond);
+        gdev->cond_initialized = false;
+        return -1;
+    }
+    gdev->mutex_initialized = true;
+    if (pthread_create(&gdev->gpu_thread, NULL, virtio_gpu_handler, vdev) !=
+        0) {
+        log_error("%s failed to create gpu thread", __func__);
+        pthread_mutex_destroy(&gdev->queue_mutex);
+        pthread_cond_destroy(&gdev->gpu_cond);
+        gdev->mutex_initialized = false;
+        gdev->cond_initialized = false;
+        return -1;
+    }
+    gdev->thread_started = true;
 
     return 0;
 }
 
 void virtio_gpu_close(VirtIODevice *vdev) {
+    if (!vdev)
+        return;
+
     log_info("virtio_gpu close");
 
     // Reclaim memory related to scanouts
     GPUDev *gdev = (GPUDev *)vdev->dev;
+    if (!gdev) {
+        free(vdev->vqs);
+        free(vdev);
+        return;
+    }
+
+    // Reclaim async part before freeing queues and display resources.
+    if (gdev->thread_started && gdev->mutex_initialized &&
+        gdev->cond_initialized) {
+        pthread_mutex_lock(&gdev->queue_mutex);
+        gdev->close = true;
+        pthread_cond_signal(&gdev->gpu_cond);
+        pthread_mutex_unlock(&gdev->queue_mutex);
+        pthread_join(gdev->gpu_thread, NULL);
+    }
+
     for (int i = 0; i < gdev->scanouts_num; ++i) {
         free(gdev->scanouts[i].current_cursor);
+        gdev->scanouts[i].current_cursor = NULL;
 
         virtio_gpu_remove_drm_framebuffer(&gdev->scanouts[i]);
 
         drmModeFreeCrtc(gdev->scanouts[i].crtc);
+        gdev->scanouts[i].crtc = NULL;
         drmModeFreeEncoder(gdev->scanouts[i].encoder);
+        gdev->scanouts[i].encoder = NULL;
         drmModeFreeConnector(gdev->scanouts[i].connector);
+        gdev->scanouts[i].connector = NULL;
 
         // Release card0_fd
         if (gdev->scanouts[i].card0_fd != -1) {
             close(gdev->scanouts[i].card0_fd);
+            gdev->scanouts[i].card0_fd = -1;
         }
     }
 
@@ -208,6 +250,7 @@ void virtio_gpu_close(VirtIODevice *vdev) {
     while (!TAILQ_EMPTY(&gdev->resource_list)) {
         GPUSimpleResource *temp = TAILQ_FIRST(&gdev->resource_list);
         TAILQ_REMOVE(&gdev->resource_list, temp, next);
+        virtio_gpu_cleanup_mapping(gdev, temp);
         free(temp);
     }
 
@@ -215,15 +258,14 @@ void virtio_gpu_close(VirtIODevice *vdev) {
     while (!TAILQ_EMPTY(&gdev->command_queue)) {
         GPUCommand *temp = TAILQ_FIRST(&gdev->command_queue);
         TAILQ_REMOVE(&gdev->command_queue, temp, next);
+        free(temp->resp_iov);
         free(temp);
     }
 
-    // Reclaim async part
-    gdev->close = true;
-    pthread_cond_signal(&gdev->gpu_cond);
-    pthread_join(gdev->gpu_thread, NULL);
-    pthread_cond_destroy(&gdev->gpu_cond);
-    pthread_mutex_destroy(&gdev->queue_mutex);
+    if (gdev->mutex_initialized)
+        pthread_mutex_destroy(&gdev->queue_mutex);
+    if (gdev->cond_initialized)
+        pthread_cond_destroy(&gdev->gpu_cond);
 
     free(gdev);
     gdev = NULL;

--- a/tools/virtio/devices/net/virtio_net.c
+++ b/tools/virtio/devices/net/virtio_net.c
@@ -26,6 +26,11 @@ static uint8_t trashbuf[1600];
 
 NetDev *init_net_dev(uint8_t mac[]) {
     NetDev *dev = malloc(sizeof(NetDev));
+    if (!dev) {
+        log_error("failed to allocate net device");
+        return NULL;
+    }
+
     dev->config.mac[0] = mac[0];
     dev->config.mac[1] = mac[1];
     dev->config.mac[2] = mac[2];
@@ -240,6 +245,7 @@ int virtio_net_init(VirtIODevice *vdev, char *devname) {
     if (set_nonblocking(net->tapfd) < 0) {
         close(net->tapfd);
         net->tapfd = -1;
+        return -1;
     }
     // register an epoll read event for tap device
     net->event = add_event(net->tapfd, EPOLLIN, virtio_net_event_handler, vdev);
@@ -254,10 +260,20 @@ int virtio_net_init(VirtIODevice *vdev, char *devname) {
 }
 
 void virtio_net_close(VirtIODevice *vdev) {
+    if (!vdev)
+        return;
+
     NetDev *dev = vdev->dev;
-    close(dev->tapfd);
-    free(dev->event);
-    free(dev);
+    if (dev) {
+        if (dev->event) {
+            remove_event(dev->event);
+            dev->event = NULL;
+        }
+        if (dev->tapfd >= 0)
+            close(dev->tapfd);
+        dev->tapfd = -1;
+        free(dev);
+    }
     free(vdev->vqs);
     free(vdev);
 }

--- a/tools/virtio/event_monitor.c
+++ b/tools/virtio/event_monitor.c
@@ -89,6 +89,27 @@ struct hvisor_event *add_event(int fd, int epoll_type,
     }
 }
 
+void remove_event(struct hvisor_event *hevent) {
+    if (!hevent)
+        return;
+
+    pthread_mutex_lock(&events_lock);
+    epoll_ctl(epoll_fd, EPOLL_CTL_DEL, hevent->fd, NULL);
+    for (int i = 0; i < events_num; i++) {
+        if (events[i] != hevent)
+            continue;
+
+        for (int j = i; j < events_num - 1; j++)
+            events[j] = events[j + 1];
+        events[events_num - 1] = NULL;
+        events_num--;
+        break;
+    }
+    pthread_mutex_unlock(&events_lock);
+
+    free(hevent);
+}
+
 // Create a thread monitoring events.
 int initialize_event_monitor() {
     epoll_fd = epoll_create1(0);

--- a/tools/virtio/event_monitor.c
+++ b/tools/virtio/event_monitor.c
@@ -24,6 +24,7 @@ pthread_t emonitor_tid;
 int closing;
 #define MAX_EVENTS 16
 struct hvisor_event *events[MAX_EVENTS];
+static pthread_mutex_t events_lock = PTHREAD_MUTEX_INITIALIZER;
 static void *epoll_loop() {
     struct epoll_event events[MAX_EVENTS];
     struct hvisor_event *hevent;
@@ -50,15 +51,23 @@ struct hvisor_event *add_event(int fd, int epoll_type,
     struct hvisor_event *hevent;
     struct epoll_event eevent;
     int ret;
+    pthread_mutex_lock(&events_lock);
     if (events_num >= MAX_EVENTS) {
         log_error("events are full");
+        pthread_mutex_unlock(&events_lock);
         return NULL;
     }
     if (fd < 0 || handler == NULL) {
         log_error("invalid fd or handler");
+        pthread_mutex_unlock(&events_lock);
         return NULL;
     }
     hevent = calloc(1, sizeof(struct hvisor_event));
+    if (!hevent) {
+        log_error("failed to allocate hvisor event");
+        pthread_mutex_unlock(&events_lock);
+        return NULL;
+    }
     hevent->handler = handler;
     hevent->param = param;
     hevent->fd = fd;
@@ -70,10 +79,12 @@ struct hvisor_event *add_event(int fd, int epoll_type,
     if (ret < 0) {
         log_error("epoll_ctl failed, errno is %d", errno);
         free(hevent);
+        pthread_mutex_unlock(&events_lock);
         return NULL;
     } else {
         events[events_num] = hevent;
         events_num++;
+        pthread_mutex_unlock(&events_lock);
         return hevent;
     }
 }
@@ -120,8 +131,11 @@ int initialize_event_monitor() {
 
 void destroy_event_monitor() {
     int i;
+    pthread_mutex_lock(&events_lock);
     for (i = 0; i < events_num; i++)
         epoll_ctl(epoll_fd, EPOLL_CTL_DEL, events[i]->fd, NULL);
+    events_num = 0;
+    pthread_mutex_unlock(&events_lock);
     close(epoll_fd);
     // When the main thread exits, the epoll thread will also exit. Therefore,
     // we do not directly terminate the epoll thread here.

--- a/tools/virtio/include/event_monitor.h
+++ b/tools/virtio/include/event_monitor.h
@@ -23,4 +23,5 @@ int initialize_event_monitor(void);
 void destroy_event_monitor();
 struct hvisor_event *add_event(int fd, int epoll_type,
                                void (*handler)(int, int, void *), void *param);
+void remove_event(struct hvisor_event *hevent);
 #endif // HVISOR_EVENT_H

--- a/tools/virtio/include/virtio.h
+++ b/tools/virtio/include/virtio.h
@@ -218,6 +218,8 @@ int virtio_start_from_json(char *json_path);
 
 int virtio_start(int argc, char *argv[]);
 
+int virtio_add(int argc, char *argv[]);
+
 void *read_file(const char *filename, uint64_t *filesize);
 
 #endif /* __HVISOR_VIRTIO_H */

--- a/tools/virtio/include/virtio.h
+++ b/tools/virtio/include/virtio.h
@@ -160,7 +160,7 @@ VirtIODevice *create_virtio_device(VirtioDeviceType dev_type, uint32_t zone_id,
                                    uint64_t base_addr, uint64_t len,
                                    uint32_t irq_id, void *arg0, void *arg1);
 
-void init_virtio_queue(VirtIODevice *vdev, VirtioDeviceType type);
+int init_virtio_queue(VirtIODevice *vdev, VirtioDeviceType type);
 
 void init_mmio_regs(VirtMmioRegs *regs, VirtioDeviceType type);
 

--- a/tools/virtio/include/virtio_blk.h
+++ b/tools/virtio/include/virtio_blk.h
@@ -50,6 +50,9 @@ typedef struct virtio_blk_dev {
     pthread_cond_t cond;
     TAILQ_HEAD(, blkp_req) procq;
     int close;
+    bool thread_started;
+    bool mutex_initialized;
+    bool cond_initialized;
 } BlkDev;
 
 BlkDev *init_blk_dev(VirtIODevice *vdev);

--- a/tools/virtio/include/virtio_gpu.h
+++ b/tools/virtio/include/virtio_gpu.h
@@ -12,11 +12,11 @@
 #define _HVISOR_VIRTIO_GPU_H
 #ifdef ENABLE_VIRTIO_GPU
 
-#include "bits/pthreadtypes.h"
 #include "linux/types.h"
 #include "sys/queue.h"
 #include "virtio.h"
 #include <linux/virtio_gpu.h>
+#include <pthread.h>
 #include <stddef.h>
 #include <stdint.h>
 #include <string.h>
@@ -193,6 +193,9 @@ typedef struct virtio_gpu_dev {
     pthread_cond_t gpu_cond;
     pthread_mutex_t queue_mutex;
     bool close;
+    bool thread_started;
+    bool cond_initialized;
+    bool mutex_initialized;
 } GPUDev;
 
 typedef struct virtio_gpu_control_cmd {

--- a/tools/virtio/virtio.c
+++ b/tools/virtio/virtio.c
@@ -224,20 +224,84 @@ inline void rw_barrier(void) {
 #endif
 }
 
-// create a virtio device.
-VirtIODevice *create_virtio_device(VirtioDeviceType dev_type, uint32_t zone_id,
-                                   uint64_t base_addr, uint64_t len,
-                                   uint32_t irq_id, void *arg0, void *arg1) {
+static void destroy_unpublished_virtio_device(VirtIODevice *vdev) {
+    if (!vdev)
+        return;
+
+    switch (vdev->type) {
+    case VirtioTBlock:
+        virtio_blk_close(vdev);
+        break;
+    case VirtioTNet:
+        virtio_net_close(vdev);
+        break;
+    case VirtioTConsole:
+        virtio_console_close(vdev);
+        break;
+    case VirtioTGPU:
+#ifdef ENABLE_VIRTIO_GPU
+        virtio_gpu_close(vdev);
+        break;
+#else
+        free(vdev->vqs);
+        free(vdev);
+        break;
+#endif
+    default:
+        free(vdev->vqs);
+        free(vdev);
+        break;
+    }
+}
+
+static int publish_virtio_devices(VirtIODevice **new_devs, size_t count) {
+    if (count == 0)
+        return 0;
+
+    pthread_mutex_lock(&VDEV_MUTEX);
+    if ((size_t)vdevs_num + count > MAX_DEVS) {
+        log_error("virtio device num exceed max limit");
+        pthread_mutex_unlock(&VDEV_MUTEX);
+        return -1;
+    }
+
+    for (size_t i = 0; i < count; i++) {
+        if (!new_devs[i] || !new_devs[i]->dev) {
+            log_error("failed to init dev");
+            pthread_mutex_unlock(&VDEV_MUTEX);
+            return -1;
+        }
+    }
+
+    for (size_t i = 0; i < count; i++) {
+        log_info("create %s success",
+                 virtio_device_type_to_string(new_devs[i]->type));
+        vdevs[vdevs_num++] = new_devs[i];
+    }
+    pthread_mutex_unlock(&VDEV_MUTEX);
+
+    return 0;
+}
+
+// create a virtio device without publishing it to vdevs[].
+static VirtIODevice *
+create_virtio_device_unpublished(VirtioDeviceType dev_type, uint32_t zone_id,
+                                 uint64_t base_addr, uint64_t len,
+                                 uint32_t irq_id, void *arg0, void *arg1) {
     log_info(
         "create virtio device type %s, zone id %d, base addr %lx, len %lx, "
         "irq id %d",
         virtio_device_type_to_string(dev_type), zone_id, base_addr, len,
         irq_id);
     VirtIODevice *vdev = NULL;
-    int is_err;
+    int is_err = -1;
     vdev = calloc(1, sizeof(VirtIODevice));
     if (vdev == NULL) {
         log_error("failed to allocate virtio device");
+#ifdef ENABLE_VIRTIO_GPU
+        if (dev_type == VirtioTGPU)
+            free(arg0);
+#endif
         return NULL;
     }
     init_mmio_regs(&vdev->regs, dev_type);
@@ -254,8 +318,10 @@ VirtIODevice *create_virtio_device(VirtioDeviceType dev_type, uint32_t zone_id,
     switch (dev_type) {
     case VirtioTBlock:
         vdev->regs.dev_feature = BLK_SUPPORTED_FEATURES;
-        init_blk_dev(vdev);
-        init_virtio_queue(vdev, dev_type);
+        if (!init_blk_dev(vdev))
+            goto err;
+        if (init_virtio_queue(vdev, dev_type) != 0)
+            goto err;
         log_info("debug: init_blk_dev and init_virtio_queue finished\n");
         is_err = virtio_blk_init(vdev, (const char *)arg0);
         break;
@@ -263,14 +329,20 @@ VirtIODevice *create_virtio_device(VirtioDeviceType dev_type, uint32_t zone_id,
     case VirtioTNet:
         vdev->regs.dev_feature = NET_SUPPORTED_FEATURES;
         vdev->dev = init_net_dev(arg0);
-        init_virtio_queue(vdev, dev_type);
+        if (!vdev->dev)
+            goto err;
+        if (init_virtio_queue(vdev, dev_type) != 0)
+            goto err;
         is_err = virtio_net_init(vdev, (char *)arg1);
         break;
 
     case VirtioTConsole:
         vdev->regs.dev_feature = CONSOLE_SUPPORTED_FEATURES;
         vdev->dev = init_console_dev();
-        init_virtio_queue(vdev, dev_type);
+        if (!vdev->dev)
+            goto err;
+        if (init_virtio_queue(vdev, dev_type) != 0)
+            goto err;
         is_err = virtio_console_init(vdev);
         break;
 
@@ -279,7 +351,10 @@ VirtIODevice *create_virtio_device(VirtioDeviceType dev_type, uint32_t zone_id,
         vdev->regs.dev_feature = GPU_SUPPORTED_FEATURES;
         vdev->dev = init_gpu_dev((GPURequestedState *)arg0);
         free(arg0);
-        init_virtio_queue(vdev, dev_type);
+        if (!vdev->dev)
+            goto err;
+        if (init_virtio_queue(vdev, dev_type) != 0)
+            goto err;
         is_err = virtio_gpu_init(vdev);
 #else
         log_error("virtio gpu is not enabled");
@@ -293,36 +368,38 @@ VirtIODevice *create_virtio_device(VirtioDeviceType dev_type, uint32_t zone_id,
     }
 
     if (is_err)
-
         goto err;
-
-    pthread_mutex_lock(&VDEV_MUTEX);
-
-    // If reaches max number of virtual devices
-    if (vdevs_num == MAX_DEVS) {
-        log_error("virtio device num exceed max limit");
-        pthread_mutex_unlock(&VDEV_MUTEX);
-        goto err;
-    }
 
     if (vdev->dev == NULL) {
         log_error("failed to init dev");
-        pthread_mutex_unlock(&VDEV_MUTEX);
         goto err;
     }
-
-    log_info("create %s success", virtio_device_type_to_string(dev_type));
-    vdevs[vdevs_num++] = vdev;
-    pthread_mutex_unlock(&VDEV_MUTEX);
 
     return vdev;
 
 err:
-    free(vdev);
+    destroy_unpublished_virtio_device(vdev);
     return NULL;
 }
 
-void init_virtio_queue(VirtIODevice *vdev, VirtioDeviceType type) {
+// create and publish a single virtio device.
+VirtIODevice *create_virtio_device(VirtioDeviceType dev_type, uint32_t zone_id,
+                                   uint64_t base_addr, uint64_t len,
+                                   uint32_t irq_id, void *arg0, void *arg1) {
+    VirtIODevice *vdev = create_virtio_device_unpublished(
+        dev_type, zone_id, base_addr, len, irq_id, arg0, arg1);
+    if (!vdev)
+        return NULL;
+
+    if (publish_virtio_devices(&vdev, 1) != 0) {
+        destroy_unpublished_virtio_device(vdev);
+        return NULL;
+    }
+
+    return vdev;
+}
+
+int init_virtio_queue(VirtIODevice *vdev, VirtioDeviceType type) {
     VirtQueue *vqs = NULL;
 
     log_info("Initializing virtio queue for zone:%d, device type:%s",
@@ -332,6 +409,8 @@ void init_virtio_queue(VirtIODevice *vdev, VirtioDeviceType type) {
     case VirtioTBlock:
         vdev->vqs_len = 1;
         vqs = malloc(sizeof(VirtQueue));
+        if (!vqs)
+            goto err;
         virtqueue_reset(vqs, 0);
         vqs->queue_num_max = VIRTQUEUE_BLK_MAX_SIZE;
         vqs->notify_handler = virtio_blk_notify_handler;
@@ -342,6 +421,8 @@ void init_virtio_queue(VirtIODevice *vdev, VirtioDeviceType type) {
     case VirtioTNet:
         vdev->vqs_len = NET_MAX_QUEUES;
         vqs = malloc(sizeof(VirtQueue) * NET_MAX_QUEUES);
+        if (!vqs)
+            goto err;
         for (int i = 0; i < NET_MAX_QUEUES; ++i) {
             virtqueue_reset(vqs, i);
             vqs[i].queue_num_max = VIRTQUEUE_NET_MAX_SIZE;
@@ -355,6 +436,8 @@ void init_virtio_queue(VirtIODevice *vdev, VirtioDeviceType type) {
     case VirtioTConsole:
         vdev->vqs_len = CONSOLE_MAX_QUEUES;
         vqs = malloc(sizeof(VirtQueue) * CONSOLE_MAX_QUEUES);
+        if (!vqs)
+            goto err;
         for (int i = 0; i < CONSOLE_MAX_QUEUES; ++i) {
             virtqueue_reset(vqs, i);
             vqs[i].queue_num_max = VIRTQUEUE_CONSOLE_MAX_SIZE;
@@ -371,6 +454,8 @@ void init_virtio_queue(VirtIODevice *vdev, VirtioDeviceType type) {
 #ifdef ENABLE_VIRTIO_GPU
         vdev->vqs_len = GPU_MAX_QUEUES;
         vqs = malloc(sizeof(VirtQueue) * GPU_MAX_QUEUES);
+        if (!vqs)
+            goto err;
         for (int i = 0; i < GPU_MAX_QUEUES; ++i) {
             virtqueue_reset(vqs, i);
             vqs[i].queue_num_max = VIRTQUEUE_GPU_MAX_SIZE;
@@ -381,12 +466,19 @@ void init_virtio_queue(VirtIODevice *vdev, VirtioDeviceType type) {
         vdev->vqs = vqs;
 #else
         log_error("virtio gpu is not enabled");
+        return -1;
 #endif
         break;
 
     default:
-        break;
+        return -1;
     }
+
+    return 0;
+
+err:
+    log_error("failed to allocate virtio queue");
+    return -1;
 }
 
 void init_mmio_regs(VirtMmioRegs *regs, VirtioDeviceType type) {
@@ -1503,8 +1595,11 @@ static int parse_virtio_device_config(cJSON *device_json, uint32_t zone_id,
     return 0;
 }
 
-static int create_virtio_device_from_config(const VirtioDeviceConfig *cfg) {
+static int create_virtio_device_from_config(const VirtioDeviceConfig *cfg,
+                                            VirtIODevice **out_vdev) {
     void *arg0 = NULL, *arg1 = NULL;
+
+    *out_vdev = NULL;
 
     if (!cfg->enabled)
         return 0;
@@ -1542,8 +1637,9 @@ static int create_virtio_device_from_config(const VirtioDeviceConfig *cfg) {
         return -1;
     }
 
-    if (!create_virtio_device(cfg->type, cfg->zone_id, cfg->addr, cfg->len,
-                              cfg->irq, arg0, arg1)) {
+    *out_vdev = create_virtio_device_unpublished(
+        cfg->type, cfg->zone_id, cfg->addr, cfg->len, cfg->irq, arg0, arg1);
+    if (!*out_vdev) {
         return -1;
     }
 
@@ -1552,12 +1648,17 @@ static int create_virtio_device_from_config(const VirtioDeviceConfig *cfg) {
 
 int create_virtio_device_from_json(cJSON *device_json, int zone_id) {
     VirtioDeviceConfig cfg;
+    VirtIODevice *vdev = NULL;
 
     if (parse_virtio_device_config(device_json, zone_id, &cfg) != 0) {
         return -1;
     }
 
-    if (create_virtio_device_from_config(&cfg) != 0) {
+    if (create_virtio_device_from_config(&cfg, &vdev) != 0) {
+        return -1;
+    }
+    if (vdev && publish_virtio_devices(&vdev, 1) != 0) {
+        destroy_unpublished_virtio_device(vdev);
         return -1;
     }
 
@@ -1852,12 +1953,41 @@ static void publish_virtio_mmio_addrs(void) {
     write_barrier();
 }
 
-static int create_virtio_zone_devices(const VirtioZoneConfig *cfg) {
-    for (size_t i = 0; i < cfg->device_num; i++) {
-        if (create_virtio_device_from_config(&cfg->devices[i]) != 0) {
-            log_error("create virtio device failed");
-            return -1;
+static int create_virtio_config_devices(const VirtioConfig *cfg) {
+    VirtIODevice *new_devs[MAX_DEVS] = {NULL};
+    size_t new_devs_num = 0;
+
+    for (size_t zi = 0; zi < cfg->zone_num; zi++) {
+        const VirtioZoneConfig *zone = &cfg->zones[zi];
+
+        for (size_t di = 0; di < zone->device_num; di++) {
+            VirtIODevice *vdev = NULL;
+            if (create_virtio_device_from_config(&zone->devices[di], &vdev) !=
+                0) {
+                log_error("create virtio device failed");
+                for (size_t i = 0; i < new_devs_num; i++)
+                    destroy_unpublished_virtio_device(new_devs[i]);
+                return -1;
+            }
+
+            if (!vdev)
+                continue;
+            if (new_devs_num == MAX_DEVS) {
+                log_error("virtio device num exceed max limit");
+                destroy_unpublished_virtio_device(vdev);
+                for (size_t i = 0; i < new_devs_num; i++)
+                    destroy_unpublished_virtio_device(new_devs[i]);
+                return -1;
+            }
+
+            new_devs[new_devs_num++] = vdev;
         }
+    }
+
+    if (publish_virtio_devices(new_devs, new_devs_num) != 0) {
+        for (size_t i = 0; i < new_devs_num; i++)
+            destroy_unpublished_virtio_device(new_devs[i]);
+        return -1;
     }
 
     return 0;
@@ -1922,11 +2052,15 @@ int virtio_start_from_json(char *json_path) {
     }
 
     for (size_t i = 0; i < config.zone_num; i++) {
-        if (mmap_virtio_zone_memory(&config.zones[i]) != 0 ||
-            create_virtio_zone_devices(&config.zones[i]) != 0) {
+        if (mmap_virtio_zone_memory(&config.zones[i]) != 0) {
             err = -1;
             goto err_out;
         }
+    }
+
+    if (create_virtio_config_devices(&config) != 0) {
+        err = -1;
+        goto err_out;
     }
 
 err_out:

--- a/tools/virtio/virtio.c
+++ b/tools/virtio/virtio.c
@@ -29,6 +29,7 @@
 #include <sys/uio.h>
 #include <time.h>
 #include <unistd.h>
+#include <net/if.h>
 
 #include "hvisor.h"
 #include "json_parse.h"
@@ -59,6 +60,39 @@ int vdevs_num;
 
 #define MAX_RAMS 4
 unsigned long long zone_mem[MAX_ZONES][MAX_RAMS][4];
+
+typedef struct virtio_memory_region_config {
+    uint64_t zone0_ipa;
+    uint64_t zonex_ipa;
+    uint64_t size;
+} VirtioMemoryRegionConfig;
+
+typedef struct virtio_device_config {
+    VirtioDeviceType type;
+    uint32_t zone_id;
+    uint64_t addr;
+    uint64_t len;
+    uint32_t irq;
+    bool enabled;
+    char img[PATH_MAX];
+    char tap[IFNAMSIZ];
+    uint8_t mac[6];
+    uint32_t width;
+    uint32_t height;
+} VirtioDeviceConfig;
+
+typedef struct virtio_zone_config {
+    uint32_t zone_id;
+    size_t memory_region_num;
+    VirtioMemoryRegionConfig memory_regions[MAX_RAMS];
+    size_t device_num;
+    VirtioDeviceConfig devices[MAX_DEVS];
+} VirtioZoneConfig;
+
+typedef struct virtio_config {
+    size_t zone_num;
+    VirtioZoneConfig zones[MAX_ZONES];
+} VirtioConfig;
 
 const char *virtio_device_type_to_string(VirtioDeviceType type) {
     switch (type) {
@@ -622,10 +656,9 @@ static const char *virtio_mmio_reg_name(uint64_t offset) {
 }
 
 uint64_t virtio_mmio_read(VirtIODevice *vdev, uint64_t offset, unsigned size) {
-    log_debug("READ virtio mmio at offset=%#x[%s], size=%d, vdev=%p, type=%d",
-              offset, virtio_mmio_reg_name(offset), size, vdev, vdev->type);
-
     if (!vdev) {
+        log_debug("READ unmatched virtio mmio at offset=%#x[%s], size=%d",
+                  offset, virtio_mmio_reg_name(offset), size);
         switch (offset) {
         case VIRTIO_MMIO_MAGIC_VALUE:
             log_debug("read VIRTIO_MMIO_MAGIC_VALUE");
@@ -640,6 +673,9 @@ uint64_t virtio_mmio_read(VirtIODevice *vdev, uint64_t offset, unsigned size) {
             return 0;
         }
     }
+
+    log_debug("READ virtio mmio at offset=%#x[%s], size=%d, vdev=%p, type=%d",
+              offset, virtio_mmio_reg_name(offset), size, vdev, vdev->type);
 
     if (offset >= VIRTIO_MMIO_CONFIG) {
         offset -= VIRTIO_MMIO_CONFIG;
@@ -724,6 +760,13 @@ uint64_t virtio_mmio_read(VirtIODevice *vdev, uint64_t offset, unsigned size) {
 
 void virtio_mmio_write(VirtIODevice *vdev, uint64_t offset, uint64_t value,
                        unsigned size) {
+    if (!vdev) {
+        log_debug("WRITE unmatched virtio mmio at offset=%#x[%s], value=%#x, "
+                  "size=%d",
+                  offset, virtio_mmio_reg_name(offset), value, size);
+        return;
+    }
+
     log_debug("WRITE virtio mmio at offset=%#x[%s], value=%#x, size=%d, "
               "vdev=%p, type=%d",
               offset, virtio_mmio_reg_name(offset), value, size, vdev,
@@ -731,9 +774,6 @@ void virtio_mmio_write(VirtIODevice *vdev, uint64_t offset, uint64_t value,
 
     VirtMmioRegs *regs = &vdev->regs;
     VirtQueue *vqs = vdev->vqs;
-    if (!vdev) {
-        return;
-    }
 
     if (offset >= VIRTIO_MMIO_CONFIG) {
         offset -= VIRTIO_MMIO_CONFIG;
@@ -1302,103 +1342,297 @@ unmap:
     return -1;
 }
 
-int create_virtio_device_from_json(cJSON *device_json, int zone_id) {
-    VirtioDeviceType dev_type = VirtioTNone;
-    uint64_t base_addr = 0, len = 0;
-    uint32_t irq_id = 0;
-
-    char *status =
-        SAFE_CJSON_GET_OBJECT_ITEM(device_json, "status")->valuestring;
-    if (strcmp(status, "disable") == 0)
-        return 0;
-
-    // Get device type
-    char *type = SAFE_CJSON_GET_OBJECT_ITEM(device_json, "type")->valuestring;
-    void *arg0, *arg1;
-
-    // Match the device type field in json
+static int parse_virtio_device_type(const char *type,
+                                    VirtioDeviceType *dev_type) {
     if (strcmp(type, "blk") == 0) {
-        dev_type = VirtioTBlock;
+        *dev_type = VirtioTBlock;
     } else if (strcmp(type, "net") == 0) {
-        dev_type = VirtioTNet;
+        *dev_type = VirtioTNet;
     } else if (strcmp(type, "console") == 0) {
-        dev_type = VirtioTConsole;
+        *dev_type = VirtioTConsole;
     } else if (strcmp(type, "gpu") == 0) {
-        dev_type = VirtioTGPU;
+        *dev_type = VirtioTGPU;
     } else {
         log_error("unknown device type %s", type);
         return -1;
     }
+    return 0;
+}
 
-    // Get base_addr, len, irq_id (mmio region base address and length, device
-    // interrupt number)
+static int parse_virtio_device_config(cJSON *device_json, uint32_t zone_id,
+                                      VirtioDeviceConfig *cfg) {
+    memset(cfg, 0, sizeof(*cfg));
+    cfg->zone_id = zone_id;
+
+    cJSON *status_json = SAFE_CJSON_GET_OBJECT_ITEM(device_json, "status");
+    if (!cJSON_IsString(status_json)) {
+        log_error("failed to parse device status");
+        return -1;
+    }
+    if (strcmp(status_json->valuestring, "disable") == 0) {
+        cfg->enabled = false;
+        return 0;
+    }
+    if (strcmp(status_json->valuestring, "enable") != 0) {
+        log_error("unknown device status %s", status_json->valuestring);
+        return -1;
+    }
+    cfg->enabled = true;
+
+    cJSON *type_json = SAFE_CJSON_GET_OBJECT_ITEM(device_json, "type");
+    if (!cJSON_IsString(type_json) ||
+        parse_virtio_device_type(type_json->valuestring, &cfg->type) != 0) {
+        log_error("failed to parse device type");
+        return -1;
+    }
+
     if (parse_json_u64(SAFE_CJSON_GET_OBJECT_ITEM(device_json, "addr"),
-                       &base_addr) != 0 ||
-        parse_json_u64(SAFE_CJSON_GET_OBJECT_ITEM(device_json, "len"), &len) !=
-            0 ||
+                       &cfg->addr) != 0 ||
+        parse_json_u64(SAFE_CJSON_GET_OBJECT_ITEM(device_json, "len"),
+                       &cfg->len) != 0 ||
         parse_json_u32(SAFE_CJSON_GET_OBJECT_ITEM(device_json, "irq"),
-                       &irq_id) != 0) {
+                       &cfg->irq) != 0) {
         log_error("failed to parse addr, len, or irq");
         return -1;
     }
 
-    // Handle other fields according to the device type
-    if (dev_type == VirtioTBlock) {
-        // virtio-blk
-        char *img = SAFE_CJSON_GET_OBJECT_ITEM(device_json, "img")->valuestring;
-        arg0 = img, arg1 = NULL;
-        log_info("debug: img is %s", img);
-    } else if (dev_type == VirtioTNet) {
-        // virtio-net
-        char *tap = SAFE_CJSON_GET_OBJECT_ITEM(device_json, "tap")->valuestring;
+    if (cfg->addr == 0 || cfg->len == 0 || cfg->irq == 0) {
+        log_error("missing arguments");
+        return -1;
+    }
+
+    if (cfg->type == VirtioTBlock) {
+        cJSON *img_json = SAFE_CJSON_GET_OBJECT_ITEM(device_json, "img");
+        if (!cJSON_IsString(img_json) || img_json->valuestring[0] == '\0') {
+            log_error("failed to parse blk img");
+            return -1;
+        }
+        if (strlen(img_json->valuestring) >= sizeof(cfg->img)) {
+            log_error("blk img path is too long");
+            return -1;
+        }
+        strncpy(cfg->img, img_json->valuestring, sizeof(cfg->img) - 1);
+        log_info("debug: img is %s", cfg->img);
+    } else if (cfg->type == VirtioTNet) {
+        cJSON *tap_json = SAFE_CJSON_GET_OBJECT_ITEM(device_json, "tap");
+        if (!cJSON_IsString(tap_json) || tap_json->valuestring[0] == '\0') {
+            log_error("failed to parse net tap");
+            return -1;
+        }
+        if (strlen(tap_json->valuestring) >= sizeof(cfg->tap)) {
+            log_error("net tap name is too long");
+            return -1;
+        }
+        strncpy(cfg->tap, tap_json->valuestring, sizeof(cfg->tap) - 1);
         cJSON *mac_json = SAFE_CJSON_GET_OBJECT_ITEM(device_json, "mac");
-        uint8_t mac[6];
+        if (SAFE_CJSON_GET_ARRAY_SIZE(mac_json) != 6) {
+            log_error("mac address should have 6 bytes");
+            return -1;
+        }
         for (int i = 0; i < 6; i++) {
             if (parse_json_u8(SAFE_CJSON_GET_ARRAY_ITEM(mac_json, i),
-                              &mac[i]) != 0) {
+                              &cfg->mac[i]) != 0) {
                 log_error("failed to parse mac address");
                 return -1;
             }
         }
-        arg0 = mac, arg1 = tap;
-    } else if (dev_type == VirtioTConsole) {
-        // virtio-console
-        arg0 = arg1 = NULL;
-    } else if (dev_type == VirtioTGPU) {
-// virtio-gpu
-#ifdef ENABLE_VIRTIO_GPU
-        // TODO: Add display device settings
-        GPURequestedState *requested_state = NULL;
-        requested_state =
-            (GPURequestedState *)malloc(sizeof(GPURequestedState));
-        memset(requested_state, 0, sizeof(GPURequestedState));
+    } else if (cfg->type == VirtioTGPU) {
         if (parse_json_u32(SAFE_CJSON_GET_OBJECT_ITEM(device_json, "width"),
-                           &requested_state->width) != 0 ||
+                           &cfg->width) != 0 ||
             parse_json_u32(SAFE_CJSON_GET_OBJECT_ITEM(device_json, "height"),
-                           &requested_state->height) != 0) {
+                           &cfg->height) != 0) {
             log_error("failed to parse gpu width or height");
-            free(requested_state);
             return -1;
         }
+    }
+
+    return 0;
+}
+
+static int create_virtio_device_from_config(const VirtioDeviceConfig *cfg) {
+    void *arg0 = NULL, *arg1 = NULL;
+
+    if (!cfg->enabled)
+        return 0;
+
+    switch (cfg->type) {
+    case VirtioTBlock:
+        arg0 = (void *)cfg->img;
+        break;
+    case VirtioTNet:
+        arg0 = (void *)cfg->mac;
+        arg1 = (void *)cfg->tap;
+        break;
+    case VirtioTConsole:
+        break;
+    case VirtioTGPU:
+#ifdef ENABLE_VIRTIO_GPU
+        GPURequestedState *requested_state = NULL;
+        requested_state = (GPURequestedState *)malloc(sizeof(*requested_state));
+        if (!requested_state) {
+            log_error("failed to allocate gpu requested state");
+            return -1;
+        }
+        memset(requested_state, 0, sizeof(*requested_state));
+        requested_state->width = cfg->width;
+        requested_state->height = cfg->height;
         arg0 = requested_state;
-        arg1 = NULL;
 #else
         log_error(
             "virtio-gpu is not enabled, please add VIRTIO_GPU=y in make cmd");
         return -1;
 #endif
-    }
-
-    // Check for missing fields
-    if (base_addr == 0 || len == 0 || irq_id == 0) {
-        log_error("missing arguments");
+        break;
+    default:
+        log_error("unsupported virtio device type");
         return -1;
     }
 
-    // Create virtio_device
-    if (!create_virtio_device(dev_type, zone_id, base_addr, len, irq_id, arg0,
-                              arg1)) {
+    if (!create_virtio_device(cfg->type, cfg->zone_id, cfg->addr, cfg->len,
+                              cfg->irq, arg0, arg1)) {
         return -1;
+    }
+
+    return 0;
+}
+
+int create_virtio_device_from_json(cJSON *device_json, int zone_id) {
+    VirtioDeviceConfig cfg;
+
+    if (parse_virtio_device_config(device_json, zone_id, &cfg) != 0) {
+        return -1;
+    }
+
+    if (create_virtio_device_from_config(&cfg) != 0) {
+        return -1;
+    }
+
+    return 0;
+}
+
+static int parse_virtio_memory_region_config(cJSON *mem_region,
+                                             VirtioMemoryRegionConfig *cfg) {
+    if (parse_json_u64(SAFE_CJSON_GET_OBJECT_ITEM(mem_region, "zone0_ipa"),
+                       &cfg->zone0_ipa) != 0 ||
+        parse_json_u64(SAFE_CJSON_GET_OBJECT_ITEM(mem_region, "zonex_ipa"),
+                       &cfg->zonex_ipa) != 0 ||
+        parse_json_u64(SAFE_CJSON_GET_OBJECT_ITEM(mem_region, "size"),
+                       &cfg->size) != 0) {
+        log_error("failed to parse memory region");
+        return -1;
+    }
+
+    return 0;
+}
+
+static int parse_virtio_zone_config(cJSON *zone_json, VirtioZoneConfig *cfg) {
+    memset(cfg, 0, sizeof(*cfg));
+
+    if (parse_json_u32(SAFE_CJSON_GET_OBJECT_ITEM(zone_json, "id"),
+                       &cfg->zone_id) != 0) {
+        log_error("failed to parse zone id");
+        return -1;
+    }
+    if (cfg->zone_id >= MAX_ZONES) {
+        log_error("Exceed maximum zone number");
+        return -1;
+    }
+
+    cJSON *memory_region_json =
+        SAFE_CJSON_GET_OBJECT_ITEM(zone_json, "memory_region");
+    size_t num_mems = SAFE_CJSON_GET_ARRAY_SIZE(memory_region_json);
+    if (num_mems > MAX_RAMS) {
+        log_error("Exceed maximum RAM region number");
+        return -1;
+    }
+    cfg->memory_region_num = num_mems;
+
+    for (size_t i = 0; i < num_mems; i++) {
+        if (parse_virtio_memory_region_config(
+                SAFE_CJSON_GET_ARRAY_ITEM(memory_region_json, i),
+                &cfg->memory_regions[i]) != 0) {
+            return -1;
+        }
+    }
+
+    cJSON *devices_json = SAFE_CJSON_GET_OBJECT_ITEM(zone_json, "devices");
+    size_t num_devices = SAFE_CJSON_GET_ARRAY_SIZE(devices_json);
+    if (num_devices > MAX_DEVS) {
+        log_error("Exceed maximum virtio device number");
+        return -1;
+    }
+    cfg->device_num = num_devices;
+
+    for (size_t i = 0; i < num_devices; i++) {
+        if (parse_virtio_device_config(
+                SAFE_CJSON_GET_ARRAY_ITEM(devices_json, i), cfg->zone_id,
+                &cfg->devices[i]) != 0) {
+            return -1;
+        }
+    }
+
+    return 0;
+}
+
+static int parse_virtio_config(cJSON *root, VirtioConfig *cfg) {
+    memset(cfg, 0, sizeof(*cfg));
+
+    cJSON *zones_json = SAFE_CJSON_GET_OBJECT_ITEM(root, "zones");
+    size_t num_zones = SAFE_CJSON_GET_ARRAY_SIZE(zones_json);
+    if (num_zones > MAX_ZONES) {
+        log_error("Exceed maximum zone number");
+        return -1;
+    }
+    cfg->zone_num = num_zones;
+
+    for (size_t i = 0; i < num_zones; i++) {
+        if (parse_virtio_zone_config(SAFE_CJSON_GET_ARRAY_ITEM(zones_json, i),
+                                     &cfg->zones[i]) != 0) {
+            return -1;
+        }
+    }
+
+    return 0;
+}
+
+static int mmap_virtio_zone_memory(const VirtioZoneConfig *cfg) {
+    for (size_t i = 0; i < cfg->memory_region_num; i++) {
+        const VirtioMemoryRegionConfig *mem = &cfg->memory_regions[i];
+        if (mem->size == 0) {
+            log_error("Invalid memory size");
+            continue;
+        }
+
+        log_info("debug: zone0_ipa is %lx, zonex_ipa is %lx, mem_size is %lx",
+                 mem->zone0_ipa, mem->zonex_ipa, mem->size);
+
+        void *virt_addr = mmap(NULL, mem->size, PROT_READ | PROT_WRITE,
+                               MAP_SHARED, ko_fd, (off_t)mem->zone0_ipa);
+
+        log_info("debug: mmap zone0_ipa is %lx, zonex_ipa is %lx, "
+                 "mem_size is %lx finished",
+                 mem->zone0_ipa, mem->zonex_ipa, mem->size);
+
+        if (virt_addr == (void *)-1) {
+            log_error("mmap failed");
+            return -1;
+        }
+
+        zone_mem[cfg->zone_id][i][VIRT_ADDR] = (uintptr_t)virt_addr;
+        zone_mem[cfg->zone_id][i][ZONE0_IPA] = mem->zone0_ipa;
+        zone_mem[cfg->zone_id][i][ZONEX_IPA] = mem->zonex_ipa;
+        zone_mem[cfg->zone_id][i][MEM_SIZE] = mem->size;
+    }
+
+    return 0;
+}
+
+static int create_virtio_zone_devices(const VirtioZoneConfig *cfg) {
+    for (size_t i = 0; i < cfg->device_num; i++) {
+        if (create_virtio_device_from_config(&cfg->devices[i]) != 0) {
+            log_error("create virtio device failed");
+            return -1;
+        }
     }
 
     return 0;
@@ -1407,105 +1641,33 @@ int create_virtio_device_from_json(cJSON *device_json, int zone_id) {
 int virtio_start_from_json(char *json_path) {
     char *buffer = NULL;
     uint64_t file_size;
-    int zone_id, num_devices = 0, err = 0, num_zones = 0;
-    void *zone0_ipa, *zonex_ipa, *virt_addr;
-    unsigned long long mem_size;
+    int err = 0;
+    VirtioConfig config;
     buffer = read_file(json_path, &file_size);
     buffer[file_size] = '\0';
 
-    // Read zones
     cJSON *root = SAFE_CJSON_PARSE(buffer);
-    cJSON *zones_json = SAFE_CJSON_GET_OBJECT_ITEM(root, "zones");
-    num_zones = SAFE_CJSON_GET_ARRAY_SIZE(zones_json);
-    if (num_zones > MAX_ZONES) {
-        log_error("Exceed maximum zone number");
+    if (!root) {
         err = -1;
         goto err_out;
     }
 
-    // Match zone information
-    for (int i = 0; i < num_zones; i++) {
-        cJSON *zone_json = SAFE_CJSON_GET_ARRAY_ITEM(zones_json, i);
-        cJSON *zone_id_json = SAFE_CJSON_GET_OBJECT_ITEM(zone_json, "id");
-        cJSON *memory_region_json =
-            SAFE_CJSON_GET_OBJECT_ITEM(zone_json, "memory_region");
-        cJSON *devices_json = SAFE_CJSON_GET_OBJECT_ITEM(zone_json, "devices");
-        uint32_t parsed_zone_id;
-        if (parse_json_u32(zone_id_json, &parsed_zone_id) != 0) {
-            log_error("failed to parse zone id");
+    if (parse_virtio_config(root, &config) != 0) {
+        err = -1;
+        goto err_out;
+    }
+
+    for (size_t i = 0; i < config.zone_num; i++) {
+        if (mmap_virtio_zone_memory(&config.zones[i]) != 0 ||
+            create_virtio_zone_devices(&config.zones[i]) != 0) {
             err = -1;
             goto err_out;
-        }
-        zone_id = (int)parsed_zone_id;
-        if (zone_id >= MAX_ZONES) {
-            log_error("Exceed maximum zone number");
-            err = -1;
-            goto err_out;
-        }
-        int num_mems = SAFE_CJSON_GET_ARRAY_SIZE(memory_region_json);
-
-        // Memory regions
-        for (int j = 0; j < num_mems; j++) {
-            cJSON *mem_region =
-                SAFE_CJSON_GET_ARRAY_ITEM(memory_region_json, j);
-            uintptr_t zone0_ipa_val = 0, zonex_ipa_val = 0;
-            uint64_t mem_size_val = 0;
-            if (parse_json_address(
-                    SAFE_CJSON_GET_OBJECT_ITEM(mem_region, "zone0_ipa"),
-                    &zone0_ipa_val) != 0 ||
-                parse_json_address(
-                    SAFE_CJSON_GET_OBJECT_ITEM(mem_region, "zonex_ipa"),
-                    &zonex_ipa_val) != 0 ||
-                parse_json_u64(SAFE_CJSON_GET_OBJECT_ITEM(mem_region, "size"),
-                               &mem_size_val) != 0) {
-                log_error("failed to parse memory region");
-                err = -1;
-                goto err_out;
-            }
-            zone0_ipa = (void *)zone0_ipa_val;
-            zonex_ipa = (void *)zonex_ipa_val;
-            mem_size = mem_size_val;
-            if (mem_size == 0) {
-                log_error("Invalid memory size");
-                continue;
-            }
-
-            log_info(
-                "debug: zone0_ipa is %lx, zonex_ipa is %lx, mem_size is %lx",
-                zone0_ipa, zonex_ipa, mem_size);
-
-            // Map from zone0_ipa
-            virt_addr = mmap(NULL, mem_size, PROT_READ | PROT_WRITE, MAP_SHARED,
-                             ko_fd, (off_t)zone0_ipa);
-
-            log_info("debug: mmap zone0_ipa is %lx, zonex_ipa is %lx, "
-                     "mem_size is %lx finished",
-                     zone0_ipa, zonex_ipa, mem_size);
-
-            if (virt_addr == (void *)-1) {
-                log_error("mmap failed");
-                err = -1;
-                goto err_out;
-            }
-            zone_mem[zone_id][j][VIRT_ADDR] = (uintptr_t)virt_addr;
-            zone_mem[zone_id][j][ZONE0_IPA] = (uintptr_t)zone0_ipa;
-            zone_mem[zone_id][j][ZONEX_IPA] = (uintptr_t)zonex_ipa;
-            zone_mem[zone_id][j][MEM_SIZE] = mem_size;
-        }
-
-        num_devices = SAFE_CJSON_GET_ARRAY_SIZE(devices_json);
-        for (int j = 0; j < num_devices; j++) {
-            cJSON *device = SAFE_CJSON_GET_ARRAY_ITEM(devices_json, j);
-            err = create_virtio_device_from_json(device, zone_id);
-            if (err) {
-                log_error("create virtio device failed");
-                goto err_out;
-            }
         }
     }
 
 err_out:
-    cJSON_Delete(root);
+    if (root)
+        cJSON_Delete(root);
     free(buffer);
     return err;
 }

--- a/tools/virtio/virtio.c
+++ b/tools/virtio/virtio.c
@@ -52,6 +52,7 @@ volatile struct virtio_bridge *virtio_bridge;
 
 pthread_mutex_t RES_MUTEX = PTHREAD_MUTEX_INITIALIZER;
 static pthread_mutex_t VDEV_MUTEX = PTHREAD_MUTEX_INITIALIZER;
+static pthread_mutex_t ZONE_MEM_MUTEX = PTHREAD_MUTEX_INITIALIZER;
 VirtIODevice *vdevs[MAX_DEVS];
 int vdevs_num;
 
@@ -145,6 +146,12 @@ int set_nonblocking(int fd) {
 }
 
 int get_zone_ram_index(void *zonex_ipa, int zone_id) {
+    if (zone_id < 0 || zone_id >= MAX_ZONES) {
+        log_error("invalid zone id %d", zone_id);
+        return -1;
+    }
+
+    pthread_mutex_lock(&ZONE_MEM_MUTEX);
     for (int i = 0; i < MAX_RAMS; i++) {
         if (zone_mem[zone_id][i][MEM_SIZE] == 0)
             continue;
@@ -152,10 +159,12 @@ int get_zone_ram_index(void *zonex_ipa, int zone_id) {
         if ((uintptr_t)zonex_ipa >= zone_mem[zone_id][i][ZONEX_IPA] &&
             (uintptr_t)zonex_ipa < zone_mem[zone_id][i][ZONEX_IPA] +
                                        zone_mem[zone_id][i][MEM_SIZE]) {
+            pthread_mutex_unlock(&ZONE_MEM_MUTEX);
             return i;
         }
     }
-    log_error("can't find zone mem index for zonex ipa %#x", zonex_ipa);
+    pthread_mutex_unlock(&ZONE_MEM_MUTEX);
+    log_error("can't find zone mem index for zonex ipa %p", zonex_ipa);
     return -1;
 }
 
@@ -439,8 +448,18 @@ bool desc_is_writable(volatile VirtqDesc *desc_table, uint16_t idx) {
 
 void *get_virt_addr(void *zonex_ipa, int zone_id) {
     int ram_idx = get_zone_ram_index(zonex_ipa, zone_id);
-    return zone_mem[zone_id][ram_idx][VIRT_ADDR] -
-           zone_mem[zone_id][ram_idx][ZONEX_IPA] + zonex_ipa;
+    void *virt_addr = NULL;
+
+    if (ram_idx < 0)
+        return NULL;
+
+    pthread_mutex_lock(&ZONE_MEM_MUTEX);
+    virt_addr = (void *)(uintptr_t)(zone_mem[zone_id][ram_idx][VIRT_ADDR] -
+                                    zone_mem[zone_id][ram_idx][ZONEX_IPA] +
+                                    (uintptr_t)zonex_ipa);
+    pthread_mutex_unlock(&ZONE_MEM_MUTEX);
+
+    return virt_addr;
 }
 
 // When virtio device is processing virtqueue, driver adding an elem to
@@ -1638,12 +1657,155 @@ static int parse_virtio_config(cJSON *root, VirtioConfig *cfg) {
     return 0;
 }
 
+static uint64_t range_end(uint64_t base, uint64_t len) {
+    if (UINT64_MAX - base < len)
+        return UINT64_MAX;
+    return base + len;
+}
+
+static bool ranges_overlap(uint64_t base_a, uint64_t len_a, uint64_t base_b,
+                           uint64_t len_b) {
+    if (len_a == 0 || len_b == 0)
+        return false;
+
+    return base_a < range_end(base_b, len_b) &&
+           base_b < range_end(base_a, len_a);
+}
+
+static bool same_memory_region(const VirtioMemoryRegionConfig *a,
+                               const VirtioMemoryRegionConfig *b) {
+    return a->zone0_ipa == b->zone0_ipa && a->zonex_ipa == b->zonex_ipa &&
+           a->size == b->size;
+}
+
+static int find_zone_memory_region_locked(uint32_t zone_id,
+                                          const VirtioMemoryRegionConfig *mem) {
+    for (int i = 0; i < MAX_RAMS; i++) {
+        VirtioMemoryRegionConfig existing = {
+            .zone0_ipa = zone_mem[zone_id][i][ZONE0_IPA],
+            .zonex_ipa = zone_mem[zone_id][i][ZONEX_IPA],
+            .size = zone_mem[zone_id][i][MEM_SIZE],
+        };
+
+        if (existing.size == 0)
+            continue;
+
+        if (same_memory_region(&existing, mem))
+            return i;
+
+        if (ranges_overlap(mem->zone0_ipa, mem->size, existing.zone0_ipa,
+                           existing.size) ||
+            ranges_overlap(mem->zonex_ipa, mem->size, existing.zonex_ipa,
+                           existing.size)) {
+            log_error("zone %d memory region conflicts with existing mapping",
+                      zone_id);
+            return -2;
+        }
+    }
+
+    return -1;
+}
+
+static int find_empty_zone_memory_slot_locked(uint32_t zone_id) {
+    for (int i = 0; i < MAX_RAMS; i++) {
+        if (zone_mem[zone_id][i][MEM_SIZE] == 0)
+            return i;
+    }
+
+    return -1;
+}
+
+static int validate_virtio_config_devices(const VirtioConfig *cfg) {
+    size_t enabled_devices = 0;
+
+    pthread_mutex_lock(&VDEV_MUTEX);
+    enabled_devices = vdevs_num;
+
+    for (size_t zi = 0; zi < cfg->zone_num; zi++) {
+        const VirtioZoneConfig *zone = &cfg->zones[zi];
+
+        for (size_t di = 0; di < zone->device_num; di++) {
+            const VirtioDeviceConfig *dev = &zone->devices[di];
+
+            if (!dev->enabled)
+                continue;
+
+            if (++enabled_devices > MAX_DEVS) {
+                log_error("virtio device num exceed max limit");
+                pthread_mutex_unlock(&VDEV_MUTEX);
+                return -1;
+            }
+
+            for (int i = 0; i < vdevs_num; i++) {
+                if (vdevs[i]->zone_id != dev->zone_id)
+                    continue;
+
+                if (ranges_overlap(dev->addr, dev->len, vdevs[i]->base_addr,
+                                   vdevs[i]->len)) {
+                    log_error("zone %d virtio-mmio range conflicts with an "
+                              "existing device",
+                              dev->zone_id);
+                    pthread_mutex_unlock(&VDEV_MUTEX);
+                    return -1;
+                }
+            }
+
+            for (size_t pzi = 0; pzi <= zi; pzi++) {
+                const VirtioZoneConfig *prev_zone = &cfg->zones[pzi];
+                size_t prev_device_num =
+                    (pzi == zi) ? di : prev_zone->device_num;
+
+                for (size_t pdi = 0; pdi < prev_device_num; pdi++) {
+                    const VirtioDeviceConfig *prev_dev =
+                        &prev_zone->devices[pdi];
+
+                    if (!prev_dev->enabled || prev_dev->zone_id != dev->zone_id)
+                        continue;
+
+                    if (ranges_overlap(dev->addr, dev->len, prev_dev->addr,
+                                       prev_dev->len)) {
+                        log_error("zone %d virtio-mmio range conflicts within "
+                                  "the new config",
+                                  dev->zone_id);
+                        pthread_mutex_unlock(&VDEV_MUTEX);
+                        return -1;
+                    }
+                }
+            }
+        }
+    }
+
+    pthread_mutex_unlock(&VDEV_MUTEX);
+    return 0;
+}
+
 static int mmap_virtio_zone_memory(const VirtioZoneConfig *cfg) {
     for (size_t i = 0; i < cfg->memory_region_num; i++) {
         const VirtioMemoryRegionConfig *mem = &cfg->memory_regions[i];
+        int slot;
         if (mem->size == 0) {
             log_error("Invalid memory size");
+            return -1;
+        }
+
+        pthread_mutex_lock(&ZONE_MEM_MUTEX);
+        slot = find_zone_memory_region_locked(cfg->zone_id, mem);
+        if (slot >= 0) {
+            pthread_mutex_unlock(&ZONE_MEM_MUTEX);
+            log_info("reuse mapped memory for zone %d, zonex_ipa is %lx",
+                     cfg->zone_id, mem->zonex_ipa);
             continue;
+        }
+        if (slot == -2) {
+            pthread_mutex_unlock(&ZONE_MEM_MUTEX);
+            return -1;
+        }
+        slot = find_empty_zone_memory_slot_locked(cfg->zone_id);
+        pthread_mutex_unlock(&ZONE_MEM_MUTEX);
+        if (slot < 0) {
+            log_error("Exceed maximum RAM region number for zone %d",
+                      cfg->zone_id);
+            return -1;
         }
 
         log_info("debug: zone0_ipa is %lx, zonex_ipa is %lx, mem_size is %lx",
@@ -1661,10 +1823,18 @@ static int mmap_virtio_zone_memory(const VirtioZoneConfig *cfg) {
             return -1;
         }
 
-        zone_mem[cfg->zone_id][i][VIRT_ADDR] = (uintptr_t)virt_addr;
-        zone_mem[cfg->zone_id][i][ZONE0_IPA] = mem->zone0_ipa;
-        zone_mem[cfg->zone_id][i][ZONEX_IPA] = mem->zonex_ipa;
-        zone_mem[cfg->zone_id][i][MEM_SIZE] = mem->size;
+        pthread_mutex_lock(&ZONE_MEM_MUTEX);
+        if (zone_mem[cfg->zone_id][slot][MEM_SIZE] != 0) {
+            pthread_mutex_unlock(&ZONE_MEM_MUTEX);
+            munmap(virt_addr, mem->size);
+            log_error("zone memory mapping slot was reused unexpectedly");
+            return -1;
+        }
+        zone_mem[cfg->zone_id][slot][VIRT_ADDR] = (uintptr_t)virt_addr;
+        zone_mem[cfg->zone_id][slot][ZONE0_IPA] = mem->zone0_ipa;
+        zone_mem[cfg->zone_id][slot][ZONEX_IPA] = mem->zonex_ipa;
+        zone_mem[cfg->zone_id][slot][MEM_SIZE] = mem->size;
+        pthread_mutex_unlock(&ZONE_MEM_MUTEX);
     }
 
     return 0;
@@ -1742,6 +1912,11 @@ int virtio_start_from_json(char *json_path) {
     }
 
     if (parse_virtio_config(root, &config) != 0) {
+        err = -1;
+        goto err_out;
+    }
+
+    if (validate_virtio_config_devices(&config) != 0) {
         err = -1;
         goto err_out;
     }

--- a/tools/virtio/virtio.c
+++ b/tools/virtio/virtio.c
@@ -12,6 +12,7 @@
 #include <fcntl.h>
 #include <getopt.h>
 #include <limits.h>
+#include <net/if.h>
 #include <signal.h>
 #include <stdatomic.h>
 #include <stdbool.h>
@@ -24,12 +25,13 @@
 #include <sys/mman.h>
 #include <sys/prctl.h>
 #include <sys/signalfd.h>
+#include <sys/socket.h>
 #include <sys/stat.h>
 #include <sys/time.h>
 #include <sys/uio.h>
+#include <sys/un.h>
 #include <time.h>
 #include <unistd.h>
-#include <net/if.h>
 
 #include "hvisor.h"
 #include "json_parse.h"
@@ -49,8 +51,26 @@ static int epoll_fd = -1;
 volatile struct virtio_bridge *virtio_bridge;
 
 pthread_mutex_t RES_MUTEX = PTHREAD_MUTEX_INITIALIZER;
+static pthread_mutex_t VDEV_MUTEX = PTHREAD_MUTEX_INITIALIZER;
 VirtIODevice *vdevs[MAX_DEVS];
 int vdevs_num;
+
+#define VIRTIO_CTRL_SOCKET_PATH "/run/hvisor-virtio.sock"
+#define VIRTIO_CTRL_OP_ADD "add"
+#define VIRTIO_CTRL_MSG_LEN 256
+
+typedef struct virtio_control_request {
+    char op[16];
+    char json_path[PATH_MAX];
+} VirtioControlRequest;
+
+typedef struct virtio_control_response {
+    int status;
+    char message[VIRTIO_CTRL_MSG_LEN];
+} VirtioControlResponse;
+
+static int ctrl_fd = -1;
+static pthread_t ctrl_tid;
 
 // the index of `zone_mem[i]`
 #define VIRT_ADDR 0
@@ -267,19 +287,24 @@ VirtIODevice *create_virtio_device(VirtioDeviceType dev_type, uint32_t zone_id,
 
         goto err;
 
+    pthread_mutex_lock(&VDEV_MUTEX);
+
     // If reaches max number of virtual devices
     if (vdevs_num == MAX_DEVS) {
         log_error("virtio device num exceed max limit");
+        pthread_mutex_unlock(&VDEV_MUTEX);
         goto err;
     }
 
     if (vdev->dev == NULL) {
         log_error("failed to init dev");
+        pthread_mutex_unlock(&VDEV_MUTEX);
         goto err;
     }
 
     log_info("create %s success", virtio_device_type_to_string(dev_type));
     vdevs[vdevs_num++] = vdev;
+    pthread_mutex_unlock(&VDEV_MUTEX);
 
     return vdev;
 
@@ -996,8 +1021,10 @@ void virtio_finish_cfg_req(uint32_t target_cpu, uint64_t value) {
 int virtio_handle_req(volatile struct device_req *req) {
     int i;
     uint64_t value = 0;
+    VirtIODevice *vdev = NULL;
 
     // Check if the request corresponds to a virtio device in a specific zone
+    pthread_mutex_lock(&VDEV_MUTEX);
     for (i = 0; i < vdevs_num; ++i) {
         if ((req->src_zone == vdevs[i]->zone_id) &&
             in_range(req->address, vdevs[i]->base_addr,
@@ -1006,6 +1033,7 @@ int virtio_handle_req(volatile struct device_req *req) {
     }
 
     if (i == vdevs_num) {
+        pthread_mutex_unlock(&VDEV_MUTEX);
         log_warn("no matched virtio dev in zone %d, address is 0x%x",
                  req->src_zone, req->address);
         value = virtio_mmio_read(NULL, 0, 0);
@@ -1013,7 +1041,8 @@ int virtio_handle_req(volatile struct device_req *req) {
         return -1;
     }
 
-    VirtIODevice *vdev = vdevs[i];
+    vdev = vdevs[i];
+    pthread_mutex_unlock(&VDEV_MUTEX);
 
     uint64_t offs = req->address - vdev->base_addr;
 
@@ -1056,6 +1085,12 @@ void virtio_close() {
     if (epoll_fd >= 0) {
         close(epoll_fd);
         epoll_fd = -1;
+    }
+
+    if (ctrl_fd >= 0) {
+        close(ctrl_fd);
+        ctrl_fd = -1;
+        unlink(VIRTIO_CTRL_SOCKET_PATH);
     }
 
     munmap((void *)virtio_bridge, MMAP_SIZE);
@@ -1528,8 +1563,11 @@ static int parse_virtio_memory_region_config(cJSON *mem_region,
 static int parse_virtio_zone_config(cJSON *zone_json, VirtioZoneConfig *cfg) {
     memset(cfg, 0, sizeof(*cfg));
 
-    if (parse_json_u32(SAFE_CJSON_GET_OBJECT_ITEM(zone_json, "id"),
-                       &cfg->zone_id) != 0) {
+    cJSON *zone_id_json = SAFE_CJSON_GET_OBJECT_ITEM(zone_json, "id");
+    if (!zone_id_json) {
+        zone_id_json = SAFE_CJSON_GET_OBJECT_ITEM(zone_json, "zone_id");
+    }
+    if (parse_json_u32(zone_id_json, &cfg->zone_id) != 0) {
         log_error("failed to parse zone id");
         return -1;
     }
@@ -1578,6 +1616,11 @@ static int parse_virtio_config(cJSON *root, VirtioConfig *cfg) {
     memset(cfg, 0, sizeof(*cfg));
 
     cJSON *zones_json = SAFE_CJSON_GET_OBJECT_ITEM(root, "zones");
+    if (!zones_json) {
+        cfg->zone_num = 1;
+        return parse_virtio_zone_config(root, &cfg->zones[0]);
+    }
+
     size_t num_zones = SAFE_CJSON_GET_ARRAY_SIZE(zones_json);
     if (num_zones > MAX_ZONES) {
         log_error("Exceed maximum zone number");
@@ -1627,6 +1670,18 @@ static int mmap_virtio_zone_memory(const VirtioZoneConfig *cfg) {
     return 0;
 }
 
+static void publish_virtio_mmio_addrs(void) {
+    pthread_mutex_lock(&VDEV_MUTEX);
+    for (int i = 0; i < vdevs_num; i++) {
+        virtio_bridge->mmio_addrs[i] = vdevs[i]->base_addr;
+    }
+    pthread_mutex_unlock(&VDEV_MUTEX);
+
+    write_barrier();
+    virtio_bridge->mmio_avail = 1;
+    write_barrier();
+}
+
 static int create_virtio_zone_devices(const VirtioZoneConfig *cfg) {
     for (size_t i = 0; i < cfg->device_num; i++) {
         if (create_virtio_device_from_config(&cfg->devices[i]) != 0) {
@@ -1636,6 +1691,40 @@ static int create_virtio_zone_devices(const VirtioZoneConfig *cfg) {
     }
 
     return 0;
+}
+
+static ssize_t read_full(int fd, void *buf, size_t len) {
+    size_t off = 0;
+
+    while (off < len) {
+        ssize_t ret = read(fd, (char *)buf + off, len - off);
+        if (ret == 0)
+            return off;
+        if (ret < 0) {
+            if (errno == EINTR)
+                continue;
+            return -1;
+        }
+        off += ret;
+    }
+
+    return off;
+}
+
+static ssize_t write_full(int fd, const void *buf, size_t len) {
+    size_t off = 0;
+
+    while (off < len) {
+        ssize_t ret = write(fd, (const char *)buf + off, len - off);
+        if (ret < 0) {
+            if (errno == EINTR)
+                continue;
+            return -1;
+        }
+        off += ret;
+    }
+
+    return off;
 }
 
 int virtio_start_from_json(char *json_path) {
@@ -1672,8 +1761,122 @@ err_out:
     return err;
 }
 
+static int virtio_add_from_json(const char *json_path) {
+    int err = virtio_start_from_json((char *)json_path);
+    if (err)
+        return err;
+
+    publish_virtio_mmio_addrs();
+    return 0;
+}
+
+static void fill_control_response(VirtioControlResponse *resp, int status,
+                                  const char *message) {
+    memset(resp, 0, sizeof(*resp));
+    resp->status = status;
+    snprintf(resp->message, sizeof(resp->message), "%s", message);
+}
+
+static void handle_control_client(int client_fd) {
+    VirtioControlRequest req;
+    VirtioControlResponse resp;
+
+    memset(&req, 0, sizeof(req));
+    if (read_full(client_fd, &req, sizeof(req)) != sizeof(req)) {
+        fill_control_response(&resp, -1,
+                              "failed to read virtio control request");
+        write_full(client_fd, &resp, sizeof(resp));
+        return;
+    }
+
+    req.op[sizeof(req.op) - 1] = '\0';
+    req.json_path[sizeof(req.json_path) - 1] = '\0';
+
+    if (strcmp(req.op, VIRTIO_CTRL_OP_ADD) != 0) {
+        fill_control_response(&resp, -1,
+                              "unsupported virtio control operation");
+    } else if (virtio_add_from_json(req.json_path) != 0) {
+        fill_control_response(&resp, -1, "virtio add failed");
+    } else {
+        fill_control_response(&resp, 0, "virtio add succeeded");
+    }
+
+    write_full(client_fd, &resp, sizeof(resp));
+}
+
+static void *virtio_control_loop(void *arg) {
+    (void)arg;
+
+    for (;;) {
+        int client_fd = accept(ctrl_fd, NULL, NULL);
+        if (client_fd < 0) {
+            if (errno == EINTR)
+                continue;
+            if (ctrl_fd < 0)
+                break;
+            log_error("accept virtio control client failed, errno is %d",
+                      errno);
+            continue;
+        }
+
+        handle_control_client(client_fd);
+        close(client_fd);
+    }
+
+    return NULL;
+}
+
+static int start_virtio_control_server(void) {
+    struct sockaddr_un addr;
+
+    mkdir("/run", 0755);
+    unlink(VIRTIO_CTRL_SOCKET_PATH);
+
+    ctrl_fd = socket(AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC, 0);
+    if (ctrl_fd < 0) {
+        log_error("create virtio control socket failed, errno is %d", errno);
+        return -1;
+    }
+
+    memset(&addr, 0, sizeof(addr));
+    addr.sun_family = AF_UNIX;
+    snprintf(addr.sun_path, sizeof(addr.sun_path), "%s",
+             VIRTIO_CTRL_SOCKET_PATH);
+
+    if (bind(ctrl_fd, (struct sockaddr *)&addr, sizeof(addr)) != 0) {
+        log_error("bind virtio control socket failed, errno is %d", errno);
+        close(ctrl_fd);
+        ctrl_fd = -1;
+        return -1;
+    }
+
+    if (listen(ctrl_fd, 8) != 0) {
+        log_error("listen virtio control socket failed, errno is %d", errno);
+        close(ctrl_fd);
+        ctrl_fd = -1;
+        unlink(VIRTIO_CTRL_SOCKET_PATH);
+        return -1;
+    }
+
+    if (pthread_create(&ctrl_tid, NULL, virtio_control_loop, NULL) != 0) {
+        log_error("create virtio control thread failed");
+        close(ctrl_fd);
+        ctrl_fd = -1;
+        unlink(VIRTIO_CTRL_SOCKET_PATH);
+        return -1;
+    }
+
+    pthread_detach(ctrl_tid);
+    return 0;
+}
+
 int virtio_start(int argc, char *argv[]) {
-    int opt, err = 0;
+    int err = 0;
+    if (argc < 4) {
+        log_error("usage: hvisor virtio start <virtio.json>");
+        return -1;
+    }
+
     err = virtio_init(); // Initialize virtio dependencies
     if (err)
         return -1;
@@ -1683,17 +1886,66 @@ int virtio_start(int argc, char *argv[]) {
     if (err)
         goto err_out;
 
-    for (int i = 0; i < vdevs_num; i++) {
-        virtio_bridge->mmio_addrs[i] = vdevs[i]->base_addr;
+    if (start_virtio_control_server() != 0) {
+        err = -1;
+        goto err_out;
     }
 
-    write_barrier();
-    virtio_bridge->mmio_avail = 1;
-    write_barrier();
+    publish_virtio_mmio_addrs();
 
     handle_virtio_requests(); // Handle virtio requests
     return 0;
 err_out:
     virtio_close();
     return err;
+}
+
+int virtio_add(int argc, char *argv[]) {
+    VirtioControlRequest req;
+    VirtioControlResponse resp;
+    struct sockaddr_un addr;
+    char resolved_path[PATH_MAX];
+    int fd;
+
+    if (argc < 4) {
+        log_error("usage: hvisor virtio add <virtio.json>");
+        return -1;
+    }
+
+    if (!realpath(argv[3], resolved_path)) {
+        log_error("failed to resolve virtio config path %s", argv[3]);
+        return -1;
+    }
+
+    fd = socket(AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC, 0);
+    if (fd < 0) {
+        log_error("create virtio add client socket failed, errno is %d", errno);
+        return -1;
+    }
+
+    memset(&addr, 0, sizeof(addr));
+    addr.sun_family = AF_UNIX;
+    snprintf(addr.sun_path, sizeof(addr.sun_path), "%s",
+             VIRTIO_CTRL_SOCKET_PATH);
+
+    if (connect(fd, (struct sockaddr *)&addr, sizeof(addr)) != 0) {
+        log_error("connect virtio daemon failed, errno is %d", errno);
+        close(fd);
+        return -1;
+    }
+
+    memset(&req, 0, sizeof(req));
+    snprintf(req.op, sizeof(req.op), "%s", VIRTIO_CTRL_OP_ADD);
+    snprintf(req.json_path, sizeof(req.json_path), "%s", resolved_path);
+
+    if (write_full(fd, &req, sizeof(req)) != sizeof(req) ||
+        read_full(fd, &resp, sizeof(resp)) != sizeof(resp)) {
+        log_error("virtio add control request failed");
+        close(fd);
+        return -1;
+    }
+
+    close(fd);
+    printf("%s\n", resp.message);
+    return resp.status;
 }

--- a/tools/virtio/virtio.c
+++ b/tools/virtio/virtio.c
@@ -207,6 +207,8 @@ inline void rw_barrier(void) {
 #endif
 }
 
+// Destroy a device that has not been published to vdevs[] yet.
+// Device-specific close paths must tolerate partially initialized state.
 static void destroy_unpublished_virtio_device(VirtIODevice *vdev) {
     if (!vdev)
         return;
@@ -237,6 +239,7 @@ static void destroy_unpublished_virtio_device(VirtIODevice *vdev) {
     }
 }
 
+// Commit staged devices to the global table in one step.
 static int publish_virtio_devices(VirtIODevice **new_devs, size_t count) {
     if (count == 0)
         return 0;
@@ -266,7 +269,7 @@ static int publish_virtio_devices(VirtIODevice **new_devs, size_t count) {
     return 0;
 }
 
-// create a virtio device without publishing it to vdevs[].
+// Create a virtio device without publishing it to vdevs[].
 static VirtIODevice *
 create_virtio_device_unpublished(VirtioDeviceType dev_type, uint32_t zone_id,
                                  uint64_t base_addr, uint64_t len,
@@ -294,10 +297,6 @@ create_virtio_device_unpublished(VirtioDeviceType dev_type, uint32_t zone_id,
     vdev->irq_id = irq_id;
     vdev->type = dev_type;
 
-    log_info("debug: vdev->base_addr is %lx, vdev->len is %lx, vdev->zone_id "
-             "is %d, vdev->irq_id is %d",
-             vdev->base_addr, vdev->len, vdev->zone_id, vdev->irq_id);
-
     switch (dev_type) {
     case VirtioTBlock:
         vdev->regs.dev_feature = BLK_SUPPORTED_FEATURES;
@@ -305,7 +304,6 @@ create_virtio_device_unpublished(VirtioDeviceType dev_type, uint32_t zone_id,
             goto err;
         if (init_virtio_queue(vdev, dev_type) != 0)
             goto err;
-        log_info("debug: init_blk_dev and init_virtio_queue finished\n");
         is_err = virtio_blk_init(vdev, (const char *)arg0);
         if (is_err == 0)
             is_err = start_blk_worker(vdev);
@@ -1552,7 +1550,6 @@ static int parse_virtio_device_config(cJSON *device_json, uint32_t zone_id,
             return -1;
         }
         strncpy(cfg->img, img_json->valuestring, sizeof(cfg->img) - 1);
-        log_info("debug: img is %s", cfg->img);
     } else if (cfg->type == VirtioTNet) {
         cJSON *tap_json = SAFE_CJSON_GET_OBJECT_ITEM(device_json, "tap");
         if (!cJSON_IsString(tap_json) || tap_json->valuestring[0] == '\0') {
@@ -1900,21 +1897,16 @@ static int mmap_virtio_zone_memory(const VirtioZoneConfig *cfg) {
         slot = zone_mem[cfg->zone_id].num_regions;
         pthread_mutex_unlock(&ZONE_MEM_MUTEX);
 
-        log_info("debug: zone0_ipa is %lx, zonex_ipa is %lx, mem_size is %lx",
-                 mem->zone0_ipa, mem->zonex_ipa, mem->size);
-
+        // Do not hold ZONE_MEM_MUTEX while mmap may block.
         void *virt_addr = mmap(NULL, mem->size, PROT_READ | PROT_WRITE,
                                MAP_SHARED, ko_fd, (off_t)mem->zone0_ipa);
-
-        log_info("debug: mmap zone0_ipa is %lx, zonex_ipa is %lx, "
-                 "mem_size is %lx finished",
-                 mem->zone0_ipa, mem->zonex_ipa, mem->size);
 
         if (virt_addr == (void *)-1) {
             log_error("mmap failed");
             return -1;
         }
 
+        // Re-check the reserved slot before recording the new mapping.
         pthread_mutex_lock(&ZONE_MEM_MUTEX);
         if (slot != zone_mem[cfg->zone_id].num_regions ||
             zone_mem[cfg->zone_id].num_regions >= CONFIG_MAX_MEMORY_REGIONS) {
@@ -1952,6 +1944,7 @@ static int create_virtio_config_devices(const VirtioConfig *cfg) {
     VirtIODevice *new_devs[MAX_DEVS] = {NULL};
     size_t new_devs_num = 0;
 
+    // new_devs[] owns staged devices until publish_virtio_devices() succeeds.
     for (size_t zi = 0; zi < cfg->zone_num; zi++) {
         const VirtioZoneConfig *zone = &cfg->zones[zi];
 

--- a/tools/virtio/virtio.c
+++ b/tools/virtio/virtio.c
@@ -269,6 +269,11 @@ static void destroy_unpublished_virtio_device(VirtIODevice *vdev) {
         free(vdev);
         break;
 #endif
+    case VirtioTSCMI:
+        free(vdev->dev);
+        free(vdev->vqs);
+        free(vdev);
+        break;
     default:
         free(vdev->vqs);
         free(vdev);
@@ -370,7 +375,10 @@ create_virtio_device_unpublished(VirtioDeviceType dev_type, uint32_t zone_id,
 #ifdef ENABLE_VIRTIO_SCMI
         vdev->regs.dev_feature = SCMI_SUPPORTED_FEATURES;
         vdev->dev = init_scmi_dev();
-        init_virtio_queue(vdev, dev_type);
+        if (!vdev->dev)
+            goto err;
+        if (init_virtio_queue(vdev, dev_type) != 0)
+            goto err;
         is_err = 0;
 #else
         log_error("virtio-scmi is not enabled");
@@ -506,6 +514,8 @@ int init_virtio_queue(VirtIODevice *vdev, VirtioDeviceType type) {
 #ifdef ENABLE_VIRTIO_SCMI
         vdev->vqs_len = SCMI_MAX_QUEUES;
         vqs = malloc(sizeof(VirtQueue) * SCMI_MAX_QUEUES);
+        if (!vqs)
+            goto err;
         for (int i = 0; i < SCMI_MAX_QUEUES; ++i) {
             virtqueue_reset(vqs, i);
             vqs[i].queue_num_max = VIRTQUEUE_SCMI_MAX_SIZE;
@@ -515,6 +525,7 @@ int init_virtio_queue(VirtIODevice *vdev, VirtioDeviceType type) {
         vdev->vqs = vqs;
 #else
         log_error("virtio scmi is not enabled");
+        return -1;
 #endif
         break;
 

--- a/tools/virtio/virtio.c
+++ b/tools/virtio/virtio.c
@@ -88,6 +88,10 @@ typedef struct virtio_control_response {
 
 static int ctrl_fd = -1;
 static pthread_t ctrl_tid;
+static atomic_bool ctrl_running = false;
+static bool ctrl_thread_started;
+static pthread_mutex_t ctrl_client_lock = PTHREAD_MUTEX_INITIALIZER;
+static int ctrl_client_fd = -1;
 
 struct zone_mem_region {
     uintptr_t virt_addr;
@@ -1358,8 +1362,38 @@ int virtio_handle_req(volatile struct device_req *req) {
     return 0;
 }
 
+static void stop_virtio_control_server(void) {
+    int client_fd = -1;
+
+    if (!ctrl_thread_started && ctrl_fd < 0)
+        return;
+
+    atomic_store(&ctrl_running, false);
+
+    if (ctrl_fd >= 0)
+        shutdown(ctrl_fd, SHUT_RDWR);
+
+    pthread_mutex_lock(&ctrl_client_lock);
+    client_fd = ctrl_client_fd;
+    pthread_mutex_unlock(&ctrl_client_lock);
+    if (client_fd >= 0)
+        shutdown(client_fd, SHUT_RDWR);
+
+    if (ctrl_thread_started) {
+        pthread_join(ctrl_tid, NULL);
+        ctrl_thread_started = false;
+    }
+
+    if (ctrl_fd >= 0) {
+        close(ctrl_fd);
+        ctrl_fd = -1;
+    }
+    unlink(VIRTIO_CTRL_SOCKET_PATH);
+}
+
 void virtio_close() {
     log_warn("virtio devices will be closed");
+    stop_virtio_control_server();
     destroy_event_monitor();
     for (int i = 0; i < vdevs_num; i++)
         vdevs[i]->virtio_close(vdevs[i]);
@@ -1378,12 +1412,6 @@ void virtio_close() {
     if (epoll_fd >= 0) {
         close(epoll_fd);
         epoll_fd = -1;
-    }
-
-    if (ctrl_fd >= 0) {
-        close(ctrl_fd);
-        ctrl_fd = -1;
-        unlink(VIRTIO_CTRL_SOCKET_PATH);
     }
 
     munmap((void *)virtio_bridge, MMAP_SIZE);
@@ -2388,19 +2416,35 @@ static void handle_control_client(int client_fd) {
 static void *virtio_control_loop(void *arg) {
     (void)arg;
 
-    for (;;) {
+    while (atomic_load(&ctrl_running)) {
         int client_fd = accept(ctrl_fd, NULL, NULL);
         if (client_fd < 0) {
             if (errno == EINTR)
                 continue;
-            if (ctrl_fd < 0)
+            if (!atomic_load(&ctrl_running) &&
+                (errno == EINVAL || errno == EBADF || errno == ENOTSOCK))
                 break;
             log_error("accept virtio control client failed, errno is %d",
                       errno);
             continue;
         }
 
+        pthread_mutex_lock(&ctrl_client_lock);
+        if (!atomic_load(&ctrl_running)) {
+            pthread_mutex_unlock(&ctrl_client_lock);
+            shutdown(client_fd, SHUT_RDWR);
+            close(client_fd);
+            break;
+        }
+        ctrl_client_fd = client_fd;
+        pthread_mutex_unlock(&ctrl_client_lock);
+
         handle_control_client(client_fd);
+
+        pthread_mutex_lock(&ctrl_client_lock);
+        if (ctrl_client_fd == client_fd)
+            ctrl_client_fd = -1;
+        pthread_mutex_unlock(&ctrl_client_lock);
         close(client_fd);
     }
 
@@ -2410,6 +2454,7 @@ static void *virtio_control_loop(void *arg) {
 static int start_virtio_control_server(void) {
     struct sockaddr_un addr;
 
+    atomic_store(&ctrl_running, false);
     mkdir("/run", 0755);
     unlink(VIRTIO_CTRL_SOCKET_PATH);
 
@@ -2439,15 +2484,20 @@ static int start_virtio_control_server(void) {
         return -1;
     }
 
+    pthread_mutex_lock(&ctrl_client_lock);
+    ctrl_client_fd = -1;
+    pthread_mutex_unlock(&ctrl_client_lock);
+    atomic_store(&ctrl_running, true);
     if (pthread_create(&ctrl_tid, NULL, virtio_control_loop, NULL) != 0) {
         log_error("create virtio control thread failed");
+        atomic_store(&ctrl_running, false);
         close(ctrl_fd);
         ctrl_fd = -1;
         unlink(VIRTIO_CTRL_SOCKET_PATH);
         return -1;
     }
 
-    pthread_detach(ctrl_tid);
+    ctrl_thread_started = true;
     return 0;
 }
 


### PR DESCRIPTION
# virtio: support dynamic device add

## Summary

Closes #57.

This PR adds a `virtio add` flow so new Virtio device configurations can be sent to an already running hvisor-tool Virtio backend daemon.

Main changes:

- Add `hvisor virtio add <virtio.json>` CLI support.
- Add a Unix domain socket control path at `/run/hvisor-virtio.sock`.
- Let `virtio add` act as a client while the running daemon performs the actual state mutation.
- Reuse the `virtio start` JSON parsing, memory mapping, validation, and device creation path for later add requests.
- Split device creation from publishing to `vdevs[]`.
- Stage all enabled devices first, then publish them together only after all devices in the add request are created successfully.
- Clean up unpublished devices on failure, including blk, console, net, gpu, virtqueue, fd, event, worker thread, mutex, and cond resources where applicable.
- Document the new workflow in `README.md` and `README-zh.md`.

## New Workflow

The existing one-shot startup flow is still supported:

```bash
nohup ./hvisor virtio start virtio_cfg.json &
./hvisor zone start zone1_linux.json
```

The new flow can add another Virtio configuration to the running daemon:

```bash
nohup ./hvisor virtio start virtio_start_empty.json &
./hvisor virtio add virtio_add_console_blk.json
./hvisor zone start zone1_linux.json
```

For MMIO Virtio devices, `virtio add` should be run before starting the zone that will use the newly added devices, unless full guest runtime hotplug is separately verified.

## Implementation Notes

- `virtio add` connects to the daemon through `/run/hvisor-virtio.sock`.
- The daemon owns shared state such as `vdevs[]`, `zone_mem[]`, event monitor state, and device-specific resources.
- `VDEV_MUTEX` protects global device table publication and MMIO address publication.
- `ZONE_MEM_MUTEX` protects zone memory mapping records.
- Device creation is staged:
  - create unpublished devices into a local list
  - if any device fails, destroy staged devices and return failure
  - if all devices succeed, publish them into `vdevs[]` together
- Device cleanup paths now tolerate partially initialized state:
  - blk checks worker thread, image fd, mutex, and cond state
  - console removes epoll event and closes pty fds only when initialized
  - net removes epoll event and closes tap fd only when initialized
  - gpu records DRM/thread/synchronization state for safer cleanup

## Validation

Runtime validation performed on QEMU AArch64 with QEMU 9.0.1:

- Started root Linux on QEMU AArch64.
- Started an empty Virtio daemon.
- Ran `virtio add` with `console + wrong blk`:
  - observed `virtio add failed`
  - confirmed no console pty residue was left in `/dev/pts`
- Ran `virtio add` with `console + valid blk`:
  - observed `virtio add succeeded`
  - started zone1 successfully
  - entered zone1 console
  - confirmed blk was accessible in the tested zone1 flow
- Also manually checked the old `virtio start` style flow after updating the hvisor side.

Static/local checks performed during the branch work:

```bash
git diff --check upstream/main...HEAD
```

## Notes

- The runtime validation in this round focuses on blk + console.
- net and gpu normal runtime paths are not fully covered by this validation; their changes are mainly initialization-failure and cleanup-path hardening.


