### PR TITLE
feat(x86_64): Multiboot2 zone loading and virtio fixes for Asterinas

### DIFF
--- a/driver/hvisor_main.c
+++ b/driver/hvisor_main.c
@@ -196,6 +196,28 @@ static int hvisor_zone_start(zone_config_t __user *arg) {
     return err;
 }
 
+static int hvisor_set_boot_mode(struct hv_zone_boot_mode __user *arg) {
+    int err;
+    struct hv_zone_boot_mode *boot_mode =
+        kmalloc(sizeof(struct hv_zone_boot_mode), GFP_KERNEL);
+
+    if (boot_mode == NULL) {
+        pr_err("hvisor.ko: failed to allocate memory for boot mode\n");
+        return -ENOMEM;
+    }
+
+    if (copy_from_user(boot_mode, arg, sizeof(struct hv_zone_boot_mode))) {
+        pr_err("hvisor.ko: failed to copy boot mode from user\n");
+        kfree(boot_mode);
+        return -EFAULT;
+    }
+
+    err = hvisor_call(HVISOR_HC_SET_BOOT_MODE, __pa(boot_mode),
+                      sizeof(struct hv_zone_boot_mode));
+    kfree(boot_mode);
+    return err;
+}
+
 // #ifndef LOONGARCH64
 // static int is_reserved_memory(unsigned long phys, unsigned long size) {
 //     struct device_node *parent, *child;
@@ -277,6 +299,9 @@ static long hvisor_ioctl(struct file *file, unsigned int ioctl,
         break;
     case HVISOR_ZONE_START:
         err = hvisor_zone_start((zone_config_t __user *)arg);
+        break;
+    case HVISOR_SET_BOOT_MODE:
+        err = hvisor_set_boot_mode((struct hv_zone_boot_mode __user *)arg);
         break;
     case HVISOR_ZONE_SHUTDOWN:
         err = hvisor_call(HVISOR_HC_SHUTDOWN_ZONE, arg, 0);

--- a/include/hvisor.h
+++ b/include/hvisor.h
@@ -72,6 +72,7 @@ typedef struct ioctl_zone_list_args zone_list_args_t;
 #define HVISOR_ZONE_LIST _IOR(1, 5, zone_list_args_t *)
 #define HVISOR_CONFIG_CHECK _IOR(1, 6, __u64 *)
 #define HVISOR_SET_EVENTFD _IOW(1, 7, int)
+#define HVISOR_SET_BOOT_MODE _IOW(1, 9, struct hv_zone_boot_mode *)
 #define HVISOR_SCMI_CLOCK_IOCTL _IOWR(1, 32, struct hvisor_scmi_clock_args)
 #define HVISOR_SCMI_RESET_IOCTL _IOWR(1, 33, struct hvisor_scmi_reset_args)
 #define HVISOR_SCMI_POWER_IOCTL _IOWR(1, 34, struct hvisor_scmi_power_args)
@@ -90,6 +91,7 @@ struct hvisor_load_image_args {
 #define HVISOR_HC_SHUTDOWN_ZONE 3
 #define HVISOR_HC_ZONE_LIST 4
 #define HVISOR_HC_CONFIG_CHECK 6
+#define HVISOR_HC_SET_BOOT_MODE 8
 
 #ifdef X86_64
 

--- a/include/zone_config.h
+++ b/include/zone_config.h
@@ -165,6 +165,12 @@ struct arch_zone_config {
 
 typedef struct arch_zone_config arch_zone_config_t;
 
+struct hv_zone_boot_mode {
+    __u32 zone_id;
+    __u32 multiboot_enabled;
+    __u64 multiboot_info_paddr;
+};
+
 struct ivc_config {
     __u32 ivc_id;
     __u32 peer_id;

--- a/tools/hvisor.c
+++ b/tools/hvisor.c
@@ -27,6 +27,7 @@
 #include "hvisor.h"
 #include "json_parse.h"
 #include "log.h"
+#include "multiboot2.h"
 #include "safe_cjson.h"
 #include "virtio.h"
 #include "zone_config.h"
@@ -98,8 +99,7 @@ int open_dev() {
     return fd;
 }
 
-static __u64 load_buffer_to_memory(const void *buf, __u64 size,
-                                   __u64 load_paddr) {
+__u64 load_buffer_to_memory(const void *buf, __u64 size, __u64 load_paddr) {
     int fd;
     long page_size;
     __u64 map_size;
@@ -238,7 +238,8 @@ static int parse_modules(const cJSON *const modules_json) {
         goto err_out;                                                          \
     }
 
-static int parse_arch_config(cJSON *root, zone_config_t *config) {
+static int parse_arch_config(cJSON *root, zone_config_t *config,
+                             int64_t gpa_to_hpa_offset, int multiboot_enabled) {
     cJSON *arch_config_json = SAFE_CJSON_GET_OBJECT_ITEM(root, "arch_config");
     CHECK_JSON_NULL(arch_config_json, "arch_config");
 
@@ -443,8 +444,10 @@ static int parse_arch_config(cJSON *root, zone_config_t *config) {
             0 ||
         parse_json_linux_u64(ioapic_size_json, &arch_config->ioapic_size) !=
             0 ||
-        parse_json_linux_u64(kernel_entry_gpa_json,
-                             &arch_config->kernel_entry_gpa) != 0) {
+        (multiboot_enabled
+             ? 0
+             : parse_json_linux_u64(kernel_entry_gpa_json,
+                                    &arch_config->kernel_entry_gpa)) != 0) {
         log_error("Failed to parse ioapic or kernel_entry_gpa\n");
         return -1;
     }
@@ -455,8 +458,10 @@ static int parse_arch_config(cJSON *root, zone_config_t *config) {
             log_error("Failed to parse boot_load_paddr\n");
             return -1;
         }
+        __u64 boot_load_hpa =
+            (__u64)((int64_t)boot_load_paddr + gpa_to_hpa_offset);
         __u64 size = load_image_to_memory(boot_filepath_json->valuestring,
-                                          boot_load_paddr);
+                                          boot_load_hpa);
 
         log_info("boot size: %llu", size);
     }
@@ -681,6 +686,8 @@ err_out:
 static int zone_start_from_json(const char *json_config_path,
                                 zone_config_t *config) {
     cJSON *root = NULL;
+    int multiboot_enabled = 0;
+    __u64 multiboot_info_paddr = 0;
 
     FILE *file = fopen(json_config_path, "r");
     if (file == NULL) {
@@ -876,10 +883,47 @@ static int zone_start_from_json(const char *json_config_path,
                   "dtb_load_paddr\n");
         goto err_out;
     }
+    // MULTIBOOT SUPPORT: Check for Multiboot mode first
+    cJSON *multiboot_json = cJSON_GetObjectItem(root, "multiboot_enabled");
+    if (multiboot_json != NULL && cJSON_IsBool(multiboot_json)) {
+        multiboot_enabled = cJSON_IsTrue(multiboot_json) ? 1 : 0;
+    } else {
+        multiboot_enabled = 0; // Default: disabled
+    }
+
+    // Calculate GPA-to-HPA offset from first memory region
+    // This is used to translate ELF p_paddr (GPA) to actual load address (HPA)
+    int64_t gpa_to_hpa_offset = 0;
+    if (multiboot_enabled && num_memory_regions > 0) {
+        // Use first RAM region for offset calculation
+        for (int i = 0; i < num_memory_regions; i++) {
+            memory_region_t *mem_region = &config->memory_regions[i];
+            if (mem_region->type == MEM_TYPE_RAM) {
+                gpa_to_hpa_offset = (int64_t)mem_region->physical_start -
+                                    (int64_t)mem_region->virtual_start;
+                break;
+            }
+        }
+    }
 
     // Load kernel image to memory
-    config->kernel_size = load_image_to_memory(
-        kernel_filepath_json->valuestring, config->kernel_load_paddr);
+    if (multiboot_enabled) {
+        // For Multiboot/ELF kernels, properly load each ELF segment
+        uint64_t elf_entry = 0;
+        uint64_t total_size = 0;
+        int ret = load_elf_kernel(kernel_filepath_json->valuestring, &elf_entry,
+                                  &total_size, gpa_to_hpa_offset);
+        if (ret != 0) {
+            log_error("Failed to load ELF segments for Multiboot kernel\n");
+            goto err_out;
+        }
+        config->kernel_size = total_size;
+        config->arch_config.kernel_entry_gpa = elf_entry;
+    } else {
+        // Non-Multiboot: load entire image to kernel_load_paddr
+        config->kernel_size = load_image_to_memory(
+            kernel_filepath_json->valuestring, config->kernel_load_paddr);
+    }
 
 // Load dtb to memory
 // x86_64 uses ACPI
@@ -890,6 +934,62 @@ static int zone_start_from_json(const char *json_config_path,
 
     log_info("Kernel size: %llu, DTB size: %llu", config->kernel_size,
              config->dtb_size);
+
+    if (multiboot_enabled) {
+        // Get kernel command line
+        cJSON *kcmdline_json = cJSON_GetObjectItem(root, "kernel_cmdline");
+        const char *cmdline = "";
+        if (kcmdline_json != NULL && kcmdline_json->valuestring != NULL) {
+            cmdline = kcmdline_json->valuestring;
+        }
+
+        // Get Multiboot info address from JSON (or use default)
+        // This is the GPA where guest expects multiboot info
+        cJSON *mb_info_paddr_json =
+            cJSON_GetObjectItem(root, "multiboot_info_paddr");
+        multiboot_info_paddr = 0x9000000; // Default GPA
+        if (mb_info_paddr_json != NULL) {
+            parse_json_linux_u64(mb_info_paddr_json, &multiboot_info_paddr);
+        }
+
+        // Copy cmdline to its own GPA so hvisor can read it before building
+        // the Multiboot2 info structure.
+        cJSON *arch_config_json = cJSON_GetObjectItem(root, "arch_config");
+        cJSON *cmdline_load_gpa_json =
+            cJSON_GetObjectItem(arch_config_json, "cmdline_load_gpa");
+        __u64 cmdline_gpa = multiboot_info_paddr;
+        if (cmdline_load_gpa_json != NULL) {
+            parse_json_linux_u64(cmdline_load_gpa_json, &cmdline_gpa);
+        }
+        if (cmdline[0] != '\0') {
+            config->arch_config.cmdline_load_gpa = cmdline_gpa;
+            uint64_t cmdline_hpa =
+                (uint64_t)((int64_t)cmdline_gpa + gpa_to_hpa_offset);
+            load_buffer_to_memory(cmdline, strlen(cmdline) + 1, cmdline_hpa);
+        }
+
+        // Load initramfs for Multiboot2 (if specified)
+        __u64 initramfs_gpa = 0;
+        uint64_t initramfs_size = 0;
+        cJSON *initramfs_filepath_json =
+            cJSON_GetObjectItem(root, "initramfs_filepath");
+        cJSON *initramfs_load_gpa_json =
+            cJSON_GetObjectItem(root, "initramfs_load_gpa");
+        if (initramfs_filepath_json != NULL &&
+            initramfs_load_gpa_json != NULL &&
+            initramfs_filepath_json->valuestring != NULL &&
+            strcmp(initramfs_filepath_json->valuestring, "null") != 0) {
+            parse_json_linux_u64(initramfs_load_gpa_json, &initramfs_gpa);
+            uint64_t initramfs_hpa =
+                (uint64_t)((int64_t)initramfs_gpa + gpa_to_hpa_offset);
+            initramfs_size = load_image_to_memory(
+                initramfs_filepath_json->valuestring, initramfs_hpa);
+            // Pass initramfs info to hvisor so it can build the Multiboot2
+            // module tag.
+            config->arch_config.initrd_load_gpa = initramfs_gpa;
+            config->arch_config.initrd_size = initramfs_size;
+        }
+    }
 
     // modules configuration is optional, return -1 if failed, otherwise 0
     if (parse_modules(modules_json)) {
@@ -907,7 +1007,7 @@ static int zone_start_from_json(const char *json_config_path,
 
 #ifndef LOONGARCH64
     // Parse architecture-specific configurations (interrupts for each platform)
-    if (parse_arch_config(root, config))
+    if (parse_arch_config(root, config, gpa_to_hpa_offset, multiboot_enabled))
         goto err_out;
 
 #endif
@@ -924,6 +1024,19 @@ static int zone_start_from_json(const char *json_config_path,
     if (fd < 0) {
         perror("zone_start: open hvisor failed");
         goto err_out;
+    }
+
+    if (multiboot_enabled) {
+        struct hv_zone_boot_mode boot_mode = {
+            .zone_id = config->zone_id,
+            .multiboot_enabled = multiboot_enabled,
+            .multiboot_info_paddr = multiboot_info_paddr,
+        };
+        if (ioctl(fd, HVISOR_SET_BOOT_MODE, &boot_mode)) {
+            perror("zone_start: set boot mode failed");
+            close(fd);
+            return -1;
+        }
     }
 
     log_info("Calling ioctl to start zone: [%s]", config->name);

--- a/tools/multiboot2.c
+++ b/tools/multiboot2.c
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: GPL-2.0-only
+/**
+ * Copyright (c) 2025 Syswonder
+ *
+ * Syswonder Website:
+ *      https://www.syswonder.org
+ *
+ * Authors:
+ *      yyda <snowmantin@foxmail.com>
+ */
+#include <stdlib.h>
+
+#include "log.h"
+#include "multiboot2.h"
+
+int load_elf_kernel(const char *elf_path, uint64_t *entry_point,
+                    uint64_t *total_size, int64_t gpa_to_hpa_offset) {
+    uint64_t file_size;
+    void *elf = read_file(elf_path, &file_size);
+
+    if (!elf) {
+        log_error("[ELF] Failed to read ELF file: %s", elf_path);
+        return -1;
+    }
+
+    unsigned char *e_ident = (unsigned char *)elf;
+    if (e_ident[0] != 0x7f || e_ident[1] != 'E' || e_ident[2] != 'L' ||
+        e_ident[3] != 'F') {
+        log_error("[ELF] Not a valid ELF file: %s", elf_path);
+        free(elf);
+        return -1;
+    }
+
+    if (e_ident[4] != 2) {
+        log_error("[ELF] Not a 64-bit ELF file: %s", elf_path);
+        free(elf);
+        return -1;
+    }
+
+    *entry_point = *(uint64_t *)((char *)elf + 24);
+
+    uint64_t e_phoff = *(uint64_t *)((char *)elf + 32);
+    uint16_t e_phentsize = *(uint16_t *)((char *)elf + 54);
+    uint16_t e_phnum = *(uint16_t *)((char *)elf + 56);
+
+    uint64_t min_paddr = UINT64_MAX;
+    uint64_t max_end = 0;
+
+    for (int i = 0; i < e_phnum; i++) {
+        char *phdr = (char *)elf + e_phoff + i * e_phentsize;
+
+        uint32_t p_type = *(uint32_t *)(phdr + 0);
+        uint64_t p_offset = *(uint64_t *)(phdr + 8);
+        uint64_t p_paddr = *(uint64_t *)(phdr + 24);
+        uint64_t p_filesz = *(uint64_t *)(phdr + 32);
+        uint64_t p_memsz = *(uint64_t *)(phdr + 40);
+
+        if (p_type != 1) { // PT_LOAD
+            continue;
+        }
+
+        if (p_offset + p_filesz > file_size) {
+            log_error("[ELF] Segment %d file offset+size exceeds file size", i);
+            free(elf);
+            return -1;
+        }
+
+        uint64_t load_paddr = (uint64_t)((int64_t)p_paddr + gpa_to_hpa_offset);
+
+        if (p_filesz > 0) {
+            load_buffer_to_memory((char *)elf + p_offset, p_filesz, load_paddr);
+        }
+
+        if (p_memsz > p_filesz) {
+            uint64_t zero_fill_start = load_paddr + p_filesz;
+            uint64_t zero_fill_size = p_memsz - p_filesz;
+            void *zero_buf = calloc(1, zero_fill_size);
+            if (!zero_buf) {
+                log_error("[ELF] Failed to allocate zero buffer for segment %d",
+                          i);
+                free(elf);
+                return -1;
+            }
+            load_buffer_to_memory(zero_buf, zero_fill_size, zero_fill_start);
+            free(zero_buf);
+        }
+
+        if (p_paddr < min_paddr) {
+            min_paddr = p_paddr;
+        }
+        if (p_paddr + p_memsz > max_end) {
+            max_end = p_paddr + p_memsz;
+        }
+    }
+
+    if (min_paddr == UINT64_MAX) {
+        *total_size = 0;
+    } else {
+        *total_size = max_end - min_paddr;
+    }
+    free(elf);
+    return 0;
+}

--- a/tools/multiboot2.h
+++ b/tools/multiboot2.h
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: GPL-2.0-only
+/**
+ * Copyright (c) 2025 Syswonder
+ *
+ * Syswonder Website:
+ *      https://www.syswonder.org
+ *
+ * Authors:
+ *      yyda <snowmantin@foxmail.com>
+ */
+#ifndef __MULTIBOOT2_H
+#define __MULTIBOOT2_H
+
+#include <stdint.h>
+
+#include "hvisor.h"
+
+void *read_file(const char *filename, uint64_t *filesize);
+__u64 load_buffer_to_memory(const void *buf, __u64 size, __u64 load_paddr);
+
+int load_elf_kernel(const char *elf_path, uint64_t *entry_point,
+                    uint64_t *total_size, int64_t gpa_to_hpa_offset);
+
+#endif /* __MULTIBOOT2_H */

--- a/tools/virtio/devices/blk/virtio_blk.c
+++ b/tools/virtio/devices/blk/virtio_blk.c
@@ -82,6 +82,12 @@ static void blkproc(BlkDev *dev, struct blkp_req *req, VirtQueue *vq) {
             err = errno;
         }
         break;
+    case VIRTIO_BLK_T_FLUSH:
+        if (fsync(dev->img_fd) < 0) {
+            log_error("fsync failed");
+            err = errno;
+        }
+        break;
     case VIRTIO_BLK_T_GET_ID: {
         char s[20] = "hvisor-virblk";
         strncpy(iov[1].iov_base, s, MIN(sizeof(s), iov[1].iov_len));
@@ -128,6 +134,7 @@ BlkDev *init_blk_dev(VirtIODevice *vdev) {
     dev->config.capacity = -1;
     dev->config.size_max = -1;
     dev->config.seg_max = BLK_SEG_MAX;
+    dev->config.blk_size = SECTOR_BSIZE;
     dev->img_fd = -1;
     dev->close = 0;
     // TODO: chang to thread poll

--- a/tools/virtio/devices/console/virtio_console.c
+++ b/tools/virtio/devices/console/virtio_console.c
@@ -124,6 +124,7 @@ int virtio_console_init(VirtIODevice *vdev) {
     // from echoing the characters sent from the master back to the master.
     tcgetattr(slave_fd, &term_io);
     cfmakeraw(&term_io);
+    term_io.c_oflag |= ONLCR;
     tcsetattr(slave_fd, TCSAFLUSH, &term_io);
     dev->slave_keepalive_fd = slave_fd;
 

--- a/tools/virtio/virtio.c
+++ b/tools/virtio/virtio.c
@@ -848,6 +848,9 @@ uint64_t virtio_mmio_read(VirtIODevice *vdev, uint64_t offset, unsigned size) {
         }
     case VIRTIO_MMIO_QUEUE_NUM_MAX:
         log_debug("read VIRTIO_MMIO_QUEUE_NUM_MAX");
+        if (vdev->regs.queue_sel >= vdev->vqs_len) {
+            return 0;
+        }
         return vdev->vqs[vdev->regs.queue_sel].queue_num_max;
     case VIRTIO_MMIO_QUEUE_READY:
         log_debug("read VIRTIO_MMIO_QUEUE_READY");
@@ -955,10 +958,7 @@ void virtio_mmio_write(VirtIODevice *vdev, uint64_t offset, uint64_t value,
         log_debug("zone %d driver set device %s, selecting queue %d",
                   vdev->zone_id, virtio_device_type_to_string(vdev->type),
                   value);
-
-        if (value < vdev->vqs_len) {
-            regs->queue_sel = value;
-        }
+        regs->queue_sel = value;
         break;
     case VIRTIO_MMIO_QUEUE_NUM:
         log_debug("zone %d driver set device %s, use virtqueue num %d",
@@ -1138,8 +1138,9 @@ int virtio_handle_req(volatile struct device_req *req) {
     if (i == vdevs_num) {
         log_warn("no matched virtio dev in zone %d, address is 0x%x",
                  req->src_zone, req->address);
-        value = virtio_mmio_read(NULL, 0, 0);
-        virtio_finish_cfg_req(req->src_cpu, value);
+        // No device at this address; return 0 so the guest sees an absent
+        // device (MagicValue != VIRT_MAGIC).
+        virtio_finish_cfg_req(req->src_cpu, 0);
         return -1;
     }
 


### PR DESCRIPTION
Supersedes #98.

- Rebase hvisor-tool onto upstream `main`.
- Add Multiboot2 boot mode support via a dedicated hypercall.
- Add `tools/multiboot2.c` / `tools/multiboot2.h` for ELF loading.
- Add virtio-blk FLUSH and block size handling.
- Fix MMIO queue probing and absent-device detection.
- Enable ONLCR for the Asterinas console.

Verified Asterinas zone1 and Linux zone1 boot to shell.