### PR TITLE
refactor(tools): decouple architecture-neutral boot mode from x86_64 Multiboot2 backend

### DIFF
--- a/tools/Makefile
+++ b/tools/Makefile
@@ -42,7 +42,7 @@ ifneq ($(ROOT),)
 CFLAGS += --sysroot=$(ROOT)
 endif
 
-include_dirs := -I../include -I./include -I./virtio/include -I../cJSON
+include_dirs := -I../include -I./include -I./virtio/include -I../cJSON -I.
 
 ifeq ($(LIBC), musl)
 include_dirs += -I./compat/

--- a/tools/boot.c
+++ b/tools/boot.c
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: GPL-2.0-only
+/**
+ * Copyright (c) 2025 Syswonder
+ *
+ * Syswonder Website:
+ *      https://www.syswonder.org
+ *
+ * Authors:
+ *      yyda <snowmantin@foxmail.com>
+ */
+#include "boot.h"
+#include "log.h"
+#include "multiboot2.h"
+
+int boot_mode_parse(struct boot_mode *mode, struct cJSON *root) {
+    *mode = (struct boot_mode){0};
+    if (multiboot2_enabled(root)) {
+        mode->kind = BOOT_MODE_MULTIBOOT2;
+    }
+    return 0;
+}
+
+int boot_mode_is_multiboot2(struct cJSON *root) {
+    return multiboot2_enabled(root);
+}
+
+int boot_mode_prepare_zone(struct boot_mode *mode, zone_config_t *config,
+                           struct cJSON *root) {
+    switch (mode->kind) {
+    case BOOT_MODE_NONE:
+        return 0;
+    case BOOT_MODE_MULTIBOOT2:
+        return multiboot2_prepare_zone(config, root,
+                                       &mode->multiboot_info_paddr);
+    }
+
+    log_error("Unsupported boot mode: %d\n", mode->kind);
+    return -1;
+}
+
+int boot_mode_apply(int fd, uint32_t zone_id, const struct boot_mode *mode) {
+    switch (mode->kind) {
+    case BOOT_MODE_NONE:
+        return 0;
+    case BOOT_MODE_MULTIBOOT2:
+        return multiboot2_set_boot_mode(fd, zone_id,
+                                        mode->multiboot_info_paddr);
+    }
+
+    log_error("Unsupported boot mode: %d\n", mode->kind);
+    return -1;
+}

--- a/tools/boot.h
+++ b/tools/boot.h
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: GPL-2.0-only
+/**
+ * Copyright (c) 2025 Syswonder
+ *
+ * Syswonder Website:
+ *      https://www.syswonder.org
+ *
+ * Authors:
+ *      yyda <snowmantin@foxmail.com>
+ */
+#ifndef __HVISOR_TOOL_BOOT_H
+#define __HVISOR_TOOL_BOOT_H
+
+#include <stdint.h>
+
+#include "hvisor.h"
+
+struct cJSON;
+
+enum boot_mode_kind {
+    BOOT_MODE_NONE = 0,
+    BOOT_MODE_MULTIBOOT2,
+};
+
+struct boot_mode {
+    enum boot_mode_kind kind;
+    __u64 multiboot_info_paddr;
+};
+
+int boot_mode_parse(struct boot_mode *mode, struct cJSON *root);
+int boot_mode_is_multiboot2(struct cJSON *root);
+int boot_mode_prepare_zone(struct boot_mode *mode, zone_config_t *config,
+                           struct cJSON *root);
+int boot_mode_apply(int fd, uint32_t zone_id, const struct boot_mode *mode);
+
+#endif /* __HVISOR_TOOL_BOOT_H */

--- a/tools/hvisor.c
+++ b/tools/hvisor.c
@@ -23,11 +23,12 @@
 #include <sys/types.h>
 #include <unistd.h>
 
+#include "boot.h"
 #include "event_monitor.h"
 #include "hvisor.h"
 #include "json_parse.h"
+#include "loader.h"
 #include "log.h"
-#include "multiboot2.h"
 #include "safe_cjson.h"
 #include "virtio.h"
 #include "zone_config.h"
@@ -132,7 +133,7 @@ static __u64 load_str_to_memory(const char *str, __u64 load_paddr) {
     return load_buffer_to_memory(str, size, load_paddr);
 }
 
-static __u64 load_image_to_memory(const char *path, __u64 load_paddr) {
+__u64 load_image_to_memory(const char *path, __u64 load_paddr) {
     if (strcmp(path, "null") == 0) {
         return 0;
     }
@@ -238,8 +239,7 @@ static int parse_modules(const cJSON *const modules_json) {
         goto err_out;                                                          \
     }
 
-static int parse_arch_config(cJSON *root, zone_config_t *config,
-                             int64_t gpa_to_hpa_offset, int multiboot_enabled) {
+static int parse_arch_config(cJSON *root, zone_config_t *config) {
     cJSON *arch_config_json = SAFE_CJSON_GET_OBJECT_ITEM(root, "arch_config");
     CHECK_JSON_NULL(arch_config_json, "arch_config");
 
@@ -403,6 +403,8 @@ static int parse_arch_config(cJSON *root, zone_config_t *config,
 #endif
 
 #ifdef X86_64
+    int multiboot_enabled = boot_mode_is_multiboot2(root);
+
     cJSON *ioapic_base_json =
         SAFE_CJSON_GET_OBJECT_ITEM(arch_config_json, "ioapic_base");
     cJSON *ioapic_size_json =
@@ -444,24 +446,21 @@ static int parse_arch_config(cJSON *root, zone_config_t *config,
             0 ||
         parse_json_linux_u64(ioapic_size_json, &arch_config->ioapic_size) !=
             0 ||
-        (multiboot_enabled
-             ? 0
-             : parse_json_linux_u64(kernel_entry_gpa_json,
-                                    &arch_config->kernel_entry_gpa)) != 0) {
+        (!multiboot_enabled &&
+         parse_json_linux_u64(kernel_entry_gpa_json,
+                              &arch_config->kernel_entry_gpa)) != 0) {
         log_error("Failed to parse ioapic or kernel_entry_gpa\n");
         return -1;
     }
 
-    if (boot_filepath_json != NULL) {
+    if (boot_filepath_json != NULL && !multiboot_enabled) {
         __u64 boot_load_paddr;
         if (parse_json_linux_u64(boot_load_paddr_json, &boot_load_paddr) != 0) {
             log_error("Failed to parse boot_load_paddr\n");
             return -1;
         }
-        __u64 boot_load_hpa =
-            (__u64)((int64_t)boot_load_paddr + gpa_to_hpa_offset);
         __u64 size = load_image_to_memory(boot_filepath_json->valuestring,
-                                          boot_load_hpa);
+                                          boot_load_paddr);
 
         log_info("boot size: %llu", size);
     }
@@ -686,8 +685,7 @@ err_out:
 static int zone_start_from_json(const char *json_config_path,
                                 zone_config_t *config) {
     cJSON *root = NULL;
-    int multiboot_enabled = 0;
-    __u64 multiboot_info_paddr = 0;
+    struct boot_mode boot_mode;
 
     FILE *file = fopen(json_config_path, "r");
     if (file == NULL) {
@@ -883,44 +881,17 @@ static int zone_start_from_json(const char *json_config_path,
                   "dtb_load_paddr\n");
         goto err_out;
     }
-    // MULTIBOOT SUPPORT: Check for Multiboot mode first
-    cJSON *multiboot_json = cJSON_GetObjectItem(root, "multiboot_enabled");
-    if (multiboot_json != NULL && cJSON_IsBool(multiboot_json)) {
-        multiboot_enabled = cJSON_IsTrue(multiboot_json) ? 1 : 0;
-    } else {
-        multiboot_enabled = 0; // Default: disabled
-    }
-
-    // Calculate GPA-to-HPA offset from first memory region
-    // This is used to translate ELF p_paddr (GPA) to actual load address (HPA)
-    int64_t gpa_to_hpa_offset = 0;
-    if (multiboot_enabled && num_memory_regions > 0) {
-        // Use first RAM region for offset calculation
-        for (int i = 0; i < num_memory_regions; i++) {
-            memory_region_t *mem_region = &config->memory_regions[i];
-            if (mem_region->type == MEM_TYPE_RAM) {
-                gpa_to_hpa_offset = (int64_t)mem_region->physical_start -
-                                    (int64_t)mem_region->virtual_start;
-                break;
-            }
-        }
-    }
+    // BOOT MODE SUPPORT: Check for a zone boot mode first
+    boot_mode_parse(&boot_mode, root);
 
     // Load kernel image to memory
-    if (multiboot_enabled) {
-        // For Multiboot/ELF kernels, properly load each ELF segment
-        uint64_t elf_entry = 0;
-        uint64_t total_size = 0;
-        int ret = load_elf_kernel(kernel_filepath_json->valuestring, &elf_entry,
-                                  &total_size, gpa_to_hpa_offset);
-        if (ret != 0) {
-            log_error("Failed to load ELF segments for Multiboot kernel\n");
+    if (boot_mode.kind != BOOT_MODE_NONE) {
+        if (boot_mode_prepare_zone(&boot_mode, config, root) != 0) {
+            log_error("Failed to prepare zone boot mode\n");
             goto err_out;
         }
-        config->kernel_size = total_size;
-        config->arch_config.kernel_entry_gpa = elf_entry;
     } else {
-        // Non-Multiboot: load entire image to kernel_load_paddr
+        // Default boot path: load the whole kernel image to kernel_load_paddr.
         config->kernel_size = load_image_to_memory(
             kernel_filepath_json->valuestring, config->kernel_load_paddr);
     }
@@ -934,62 +905,6 @@ static int zone_start_from_json(const char *json_config_path,
 
     log_info("Kernel size: %llu, DTB size: %llu", config->kernel_size,
              config->dtb_size);
-
-    if (multiboot_enabled) {
-        // Get kernel command line
-        cJSON *kcmdline_json = cJSON_GetObjectItem(root, "kernel_cmdline");
-        const char *cmdline = "";
-        if (kcmdline_json != NULL && kcmdline_json->valuestring != NULL) {
-            cmdline = kcmdline_json->valuestring;
-        }
-
-        // Get Multiboot info address from JSON (or use default)
-        // This is the GPA where guest expects multiboot info
-        cJSON *mb_info_paddr_json =
-            cJSON_GetObjectItem(root, "multiboot_info_paddr");
-        multiboot_info_paddr = 0x9000000; // Default GPA
-        if (mb_info_paddr_json != NULL) {
-            parse_json_linux_u64(mb_info_paddr_json, &multiboot_info_paddr);
-        }
-
-        // Copy cmdline to its own GPA so hvisor can read it before building
-        // the Multiboot2 info structure.
-        cJSON *arch_config_json = cJSON_GetObjectItem(root, "arch_config");
-        cJSON *cmdline_load_gpa_json =
-            cJSON_GetObjectItem(arch_config_json, "cmdline_load_gpa");
-        __u64 cmdline_gpa = multiboot_info_paddr;
-        if (cmdline_load_gpa_json != NULL) {
-            parse_json_linux_u64(cmdline_load_gpa_json, &cmdline_gpa);
-        }
-        if (cmdline[0] != '\0') {
-            config->arch_config.cmdline_load_gpa = cmdline_gpa;
-            uint64_t cmdline_hpa =
-                (uint64_t)((int64_t)cmdline_gpa + gpa_to_hpa_offset);
-            load_buffer_to_memory(cmdline, strlen(cmdline) + 1, cmdline_hpa);
-        }
-
-        // Load initramfs for Multiboot2 (if specified)
-        __u64 initramfs_gpa = 0;
-        uint64_t initramfs_size = 0;
-        cJSON *initramfs_filepath_json =
-            cJSON_GetObjectItem(root, "initramfs_filepath");
-        cJSON *initramfs_load_gpa_json =
-            cJSON_GetObjectItem(root, "initramfs_load_gpa");
-        if (initramfs_filepath_json != NULL &&
-            initramfs_load_gpa_json != NULL &&
-            initramfs_filepath_json->valuestring != NULL &&
-            strcmp(initramfs_filepath_json->valuestring, "null") != 0) {
-            parse_json_linux_u64(initramfs_load_gpa_json, &initramfs_gpa);
-            uint64_t initramfs_hpa =
-                (uint64_t)((int64_t)initramfs_gpa + gpa_to_hpa_offset);
-            initramfs_size = load_image_to_memory(
-                initramfs_filepath_json->valuestring, initramfs_hpa);
-            // Pass initramfs info to hvisor so it can build the Multiboot2
-            // module tag.
-            config->arch_config.initrd_load_gpa = initramfs_gpa;
-            config->arch_config.initrd_size = initramfs_size;
-        }
-    }
 
     // modules configuration is optional, return -1 if failed, otherwise 0
     if (parse_modules(modules_json)) {
@@ -1007,7 +922,7 @@ static int zone_start_from_json(const char *json_config_path,
 
 #ifndef LOONGARCH64
     // Parse architecture-specific configurations (interrupts for each platform)
-    if (parse_arch_config(root, config, gpa_to_hpa_offset, multiboot_enabled))
+    if (parse_arch_config(root, config))
         goto err_out;
 
 #endif
@@ -1026,14 +941,8 @@ static int zone_start_from_json(const char *json_config_path,
         goto err_out;
     }
 
-    if (multiboot_enabled) {
-        struct hv_zone_boot_mode boot_mode = {
-            .zone_id = config->zone_id,
-            .multiboot_enabled = multiboot_enabled,
-            .multiboot_info_paddr = multiboot_info_paddr,
-        };
-        if (ioctl(fd, HVISOR_SET_BOOT_MODE, &boot_mode)) {
-            perror("zone_start: set boot mode failed");
+    if (boot_mode.kind != BOOT_MODE_NONE) {
+        if (boot_mode_apply(fd, config->zone_id, &boot_mode) != 0) {
             close(fd);
             return -1;
         }

--- a/tools/loader.h
+++ b/tools/loader.h
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: GPL-2.0-only
+/**
+ * Copyright (c) 2025 Syswonder
+ *
+ * Syswonder Website:
+ *      https://www.syswonder.org
+ *
+ * Authors:
+ *      yyda <snowmantin@foxmail.com>
+ */
+#ifndef __HVISOR_TOOL_LOADER_H
+#define __HVISOR_TOOL_LOADER_H
+
+#include <stdint.h>
+
+#include "hvisor.h"
+
+void *read_file(const char *filename, uint64_t *filesize);
+__u64 load_buffer_to_memory(const void *buf, __u64 size, __u64 load_paddr);
+__u64 load_image_to_memory(const char *path, __u64 load_paddr);
+
+#endif /* __HVISOR_TOOL_LOADER_H */

--- a/tools/multiboot2.c
+++ b/tools/multiboot2.c
@@ -8,10 +8,24 @@
  * Authors:
  *      yyda <snowmantin@foxmail.com>
  */
+#include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
+#include <sys/ioctl.h>
 
+#include "json_parse.h"
+#include "loader.h"
 #include "log.h"
 #include "multiboot2.h"
+#include "safe_cjson.h"
+
+int multiboot2_enabled(struct cJSON *root) {
+    cJSON *multiboot_json = cJSON_GetObjectItem(root, "multiboot_enabled");
+    if (multiboot_json != NULL && cJSON_IsBool(multiboot_json)) {
+        return cJSON_IsTrue(multiboot_json) ? 1 : 0;
+    }
+    return 0;
+}
 
 int load_elf_kernel(const char *elf_path, uint64_t *entry_point,
                     uint64_t *total_size, int64_t gpa_to_hpa_offset) {
@@ -100,4 +114,134 @@ int load_elf_kernel(const char *elf_path, uint64_t *entry_point,
     }
     free(elf);
     return 0;
+}
+
+int multiboot2_prepare_zone(zone_config_t *config, struct cJSON *root,
+                            __u64 *multiboot_info_paddr) {
+#ifdef X86_64
+    int64_t gpa_to_hpa_offset = 0;
+    for (uint32_t i = 0; i < config->num_memory_regions; i++) {
+        memory_region_t *mem_region = &config->memory_regions[i];
+        if (mem_region->type == MEM_TYPE_RAM) {
+            gpa_to_hpa_offset = (int64_t)mem_region->physical_start -
+                                (int64_t)mem_region->virtual_start;
+            break;
+        }
+    }
+
+    cJSON *kernel_filepath_json = cJSON_GetObjectItem(root, "kernel_filepath");
+    if (kernel_filepath_json == NULL ||
+        kernel_filepath_json->valuestring == NULL) {
+        log_error("[MULTIBOOT2] Missing kernel_filepath");
+        return -1;
+    }
+
+    uint64_t elf_entry = 0;
+    uint64_t total_size = 0;
+    if (load_elf_kernel(kernel_filepath_json->valuestring, &elf_entry,
+                        &total_size, gpa_to_hpa_offset) != 0) {
+        log_error("Failed to load ELF segments for Multiboot kernel\n");
+        return -1;
+    }
+    config->kernel_size = total_size;
+    config->arch_config.kernel_entry_gpa = elf_entry;
+
+    cJSON *kcmdline_json = cJSON_GetObjectItem(root, "kernel_cmdline");
+    const char *cmdline = "";
+    if (kcmdline_json != NULL && kcmdline_json->valuestring != NULL) {
+        cmdline = kcmdline_json->valuestring;
+    }
+
+    cJSON *mb_info_paddr_json =
+        cJSON_GetObjectItem(root, "multiboot_info_paddr");
+    *multiboot_info_paddr = 0x9000000; // Default GPA
+    if (mb_info_paddr_json != NULL &&
+        parse_json_linux_u64(mb_info_paddr_json, multiboot_info_paddr) != 0) {
+        log_error("Failed to parse multiboot_info_paddr\n");
+        return -1;
+    }
+
+    cJSON *arch_config_json = cJSON_GetObjectItem(root, "arch_config");
+    cJSON *boot_filepath_json =
+        cJSON_GetObjectItem(arch_config_json, "boot_filepath");
+    cJSON *boot_load_paddr_json =
+        cJSON_GetObjectItem(arch_config_json, "boot_load_paddr");
+    if (boot_filepath_json != NULL && boot_filepath_json->valuestring != NULL &&
+        boot_load_paddr_json != NULL) {
+        __u64 boot_load_paddr = 0;
+        if (parse_json_linux_u64(boot_load_paddr_json, &boot_load_paddr) != 0) {
+            log_error("Failed to parse boot_load_paddr\n");
+            return -1;
+        }
+        __u64 boot_load_hpa =
+            (__u64)((int64_t)boot_load_paddr + gpa_to_hpa_offset);
+        load_image_to_memory(boot_filepath_json->valuestring, boot_load_hpa);
+    }
+
+    cJSON *cmdline_load_gpa_json =
+        cJSON_GetObjectItem(arch_config_json, "cmdline_load_gpa");
+    __u64 cmdline_gpa = *multiboot_info_paddr;
+    if (cmdline_load_gpa_json != NULL &&
+        parse_json_linux_u64(cmdline_load_gpa_json, &cmdline_gpa) != 0) {
+        log_error("Failed to parse cmdline_load_gpa\n");
+        return -1;
+    }
+    if (cmdline[0] != '\0') {
+        config->arch_config.cmdline_load_gpa = cmdline_gpa;
+        uint64_t cmdline_hpa =
+            (uint64_t)((int64_t)cmdline_gpa + gpa_to_hpa_offset);
+        load_buffer_to_memory(cmdline, strlen(cmdline) + 1, cmdline_hpa);
+    }
+
+    __u64 initramfs_gpa = 0;
+    uint64_t initramfs_size = 0;
+    cJSON *initramfs_filepath_json =
+        cJSON_GetObjectItem(root, "initramfs_filepath");
+    cJSON *initramfs_load_gpa_json =
+        cJSON_GetObjectItem(root, "initramfs_load_gpa");
+    if (initramfs_filepath_json != NULL && initramfs_load_gpa_json != NULL &&
+        initramfs_filepath_json->valuestring != NULL &&
+        strcmp(initramfs_filepath_json->valuestring, "null") != 0) {
+        if (parse_json_linux_u64(initramfs_load_gpa_json, &initramfs_gpa) !=
+            0) {
+            log_error("Failed to parse initramfs_load_gpa\n");
+            return -1;
+        }
+        uint64_t initramfs_hpa =
+            (uint64_t)((int64_t)initramfs_gpa + gpa_to_hpa_offset);
+        initramfs_size = load_image_to_memory(
+            initramfs_filepath_json->valuestring, initramfs_hpa);
+        config->arch_config.initrd_load_gpa = initramfs_gpa;
+        config->arch_config.initrd_size = initramfs_size;
+    }
+
+    return 0;
+#else
+    (void)config;
+    (void)root;
+    (void)multiboot_info_paddr;
+    log_error("Multiboot2 is only supported on x86_64");
+    return -1;
+#endif
+}
+
+int multiboot2_set_boot_mode(int fd, uint32_t zone_id,
+                             __u64 multiboot_info_paddr) {
+#ifdef X86_64
+    struct hv_zone_boot_mode boot_mode = {
+        .zone_id = zone_id,
+        .multiboot_enabled = 1,
+        .multiboot_info_paddr = multiboot_info_paddr,
+    };
+    if (ioctl(fd, HVISOR_SET_BOOT_MODE, &boot_mode)) {
+        perror("zone_start: set boot mode failed");
+        return -1;
+    }
+    return 0;
+#else
+    (void)fd;
+    (void)zone_id;
+    (void)multiboot_info_paddr;
+    return -1;
+#endif
 }

--- a/tools/multiboot2.h
+++ b/tools/multiboot2.h
@@ -15,10 +15,14 @@
 
 #include "hvisor.h"
 
-void *read_file(const char *filename, uint64_t *filesize);
-__u64 load_buffer_to_memory(const void *buf, __u64 size, __u64 load_paddr);
+struct cJSON;
 
+int multiboot2_enabled(struct cJSON *root);
 int load_elf_kernel(const char *elf_path, uint64_t *entry_point,
                     uint64_t *total_size, int64_t gpa_to_hpa_offset);
+int multiboot2_prepare_zone(zone_config_t *config, struct cJSON *root,
+                            __u64 *multiboot_info_paddr);
+int multiboot2_set_boot_mode(int fd, uint32_t zone_id,
+                             __u64 multiboot_info_paddr);
 
 #endif /* __MULTIBOOT2_H */

--- a/tools/virtio/include/virtio.h
+++ b/tools/virtio/include/virtio.h
@@ -250,6 +250,4 @@ int virtio_start_from_json(char *json_path);
 
 int virtio_start(int argc, char *argv[]);
 
-void *read_file(const char *filename, uint64_t *filesize);
-
 #endif /* __HVISOR_VIRTIO_H */

--- a/tools/virtio/virtio.c
+++ b/tools/virtio/virtio.c
@@ -33,6 +33,7 @@
 
 #include "hvisor.h"
 #include "json_parse.h"
+#include "loader.h"
 #include "log.h"
 #include "safe_cjson.h"
 #include "virtio.h"


### PR DESCRIPTION
This refactor decouples the architecture-neutral boot mode flow from the x86_64 Multiboot2 backend, on top of the merged hvisor-tool Multiboot2 support (#113).

Changes:
- Add `tools/boot.{c,h}` as the generic boot mode entry point.
- Move Multiboot2 loading and preparation behind the x86_64 backend.
- Split common loader helpers into `tools/loader.h`.
- Keep the default non-Multiboot image load path unchanged.

Verified:
- x86_64 hvisor-tool build passes.
- aarch64/riscv64 tools cross-compile.
- Asterinas and Linux zone1 both start under x86_64 QEMU.