### PR TITLE
feat(x86_64): query ECAM base before starting zones

### DIFF
--- a/driver/hvisor_main.c
+++ b/driver/hvisor_main.c
@@ -260,6 +260,34 @@ static int hvisor_config_check(u64 __user *arg) {
     return err;
 }
 
+static int hvisor_get_ecam_base(u64 __user *arg) {
+    int err = 0;
+    u64 *ecam_base;
+
+    ecam_base = kmalloc(sizeof(u64), GFP_KERNEL);
+    if (ecam_base == NULL) {
+        pr_err("hvisor.ko: failed to allocate memory for ecam base\n");
+        return -ENOMEM;
+    }
+    *ecam_base = 0;
+
+    err = hvisor_call(HVISOR_HC_GET_ECAM_BASE, __pa(ecam_base), 0);
+    if (err != 0) {
+        pr_err("hvisor.ko: failed to get ecam base\n");
+        kfree(ecam_base);
+        return err;
+    }
+
+    if (copy_to_user(arg, ecam_base, sizeof(u64))) {
+        pr_err("hvisor.ko: failed to copy ecam base to user\n");
+        kfree(ecam_base);
+        return -EFAULT;
+    }
+
+    kfree(ecam_base);
+    return 0;
+}
+
 static int hvisor_zone_list(zone_list_args_t __user *arg) {
     int ret;
     zone_info_t *zones;
@@ -314,6 +342,9 @@ static long hvisor_ioctl(struct file *file, unsigned int ioctl,
         break;
     case HVISOR_CONFIG_CHECK:
         err = hvisor_config_check((u64 __user *)arg);
+        break;
+    case HVISOR_GET_ECAM_BASE:
+        err = hvisor_get_ecam_base((u64 __user *)arg);
         break;
     case HVISOR_SET_EVENTFD: {
         struct eventfd_ctx *ctx = eventfd_ctx_fdget((int)arg);

--- a/include/hvisor.h
+++ b/include/hvisor.h
@@ -73,6 +73,7 @@ typedef struct ioctl_zone_list_args zone_list_args_t;
 #define HVISOR_CONFIG_CHECK _IOR(1, 6, __u64 *)
 #define HVISOR_SET_EVENTFD _IOW(1, 7, int)
 #define HVISOR_SET_BOOT_MODE _IOW(1, 9, struct hv_zone_boot_mode *)
+#define HVISOR_GET_ECAM_BASE _IOR(1, 10, __u64 *)
 #define HVISOR_SCMI_CLOCK_IOCTL _IOWR(1, 32, struct hvisor_scmi_clock_args)
 #define HVISOR_SCMI_RESET_IOCTL _IOWR(1, 33, struct hvisor_scmi_reset_args)
 #define HVISOR_SCMI_POWER_IOCTL _IOWR(1, 34, struct hvisor_scmi_power_args)
@@ -92,6 +93,7 @@ struct hvisor_load_image_args {
 #define HVISOR_HC_ZONE_LIST 4
 #define HVISOR_HC_CONFIG_CHECK 6
 #define HVISOR_HC_SET_BOOT_MODE 8
+#define HVISOR_HC_GET_ECAM_BASE 9
 
 #ifdef X86_64
 

--- a/tools/hvisor.c
+++ b/tools/hvisor.c
@@ -682,6 +682,34 @@ err_out:
     return -1;
 }
 
+/*
+ * Non-x86 hypercall implementations currently return 0
+ */
+static int zone_apply_dynamic_ecam(int fd, zone_config_t *config) {
+    uint64_t ecam_base = 0;
+
+    if (config->num_pci_bus == 0) {
+        return 0;
+    }
+
+    if (ioctl(fd, HVISOR_GET_ECAM_BASE, &ecam_base) != 0) {
+        perror("zone_start: HVISOR_GET_ECAM_BASE failed");
+        return -1;
+    }
+
+    if (ecam_base == 0) {
+        return 0;
+    }
+
+    if (config->pci_config[0].ecam_base != ecam_base) {
+        log_info("zone %s: dynamic ECAM base 0x%llx -> 0x%llx", config->name,
+                 config->pci_config[0].ecam_base, ecam_base);
+        config->pci_config[0].ecam_base = ecam_base;
+    }
+
+    return 0;
+}
+
 static int zone_start_from_json(const char *json_config_path,
                                 zone_config_t *config) {
     cJSON *root = NULL;
@@ -939,6 +967,11 @@ static int zone_start_from_json(const char *json_config_path,
     if (fd < 0) {
         perror("zone_start: open hvisor failed");
         goto err_out;
+    }
+
+    if (zone_apply_dynamic_ecam(fd, config) != 0) {
+        close(fd);
+        return -1;
     }
 
     if (boot_mode.kind != BOOT_MODE_NONE) {


### PR DESCRIPTION
## Motivation

ECAM base can differ across x86_64 devices. Zone JSON files currently hardcode `ecam_base`, so the same hvisor-tool can pass a wrong PCI ECAM address to hvisor.

## Changes

- `include/hvisor.h`: add `HVISOR_GET_ECAM_BASE` ioctl and `HVISOR_HC_GET_ECAM_BASE = 9`.
- `driver/hvisor_main.c`: add `hvisor_get_ecam_base()` to query the ECAM base from hvisor and copy it back to userspace.
- `tools/hvisor.c`: before starting a zone, query the ECAM base and override `pci_config[0].ecam_base` when the queried value is non-zero and differs from JSON.

## Verification

- hvisor-tool x86_64 build passes.
- Tested with zone JSON `ecam_base=0x12345000`; hvisor receives `0xe0000000` after the correction, Asterinas starts and the shell responds to `echo ci-ok`.

Depends on the hvisor PR that adds the `HvGetEcamBase` hypercall.